### PR TITLE
Added required arguments for optional_param and required_param

### DIFF
--- a/SSO.php
+++ b/SSO.php
@@ -26,11 +26,11 @@ if(empty($CFG))
 require_once ($CFG->libdir . '/weblib.php');
 require_once("lib/block_panopto_lib.php");
 
-$server_name = required_param("serverName");
-$callback_url = required_param("callbackURL");
-$expiration = required_param("expiration");
-$request_auth_code = required_param("authCode");
-$action = optional_param("action");
+$server_name = required_param("serverName", PARAM_HOST);
+$callback_url = required_param("callbackURL", PARAM_URL);
+$expiration = preg_replace('/[^0-9\.]/', '', required_param("expiration", PARAM_RAW)); // A float doesn't have the required precision
+$request_auth_code = required_param("authCode", PARAM_ALPHANUM);
+$action = optional_param("action", "", PARAM_ALPHA);
 
 $relogin = ($action == "relogin");
 

--- a/provision_course.php
+++ b/provision_course.php
@@ -55,11 +55,7 @@ require_login();
 $context = get_context_instance(CONTEXT_SYSTEM);
 $PAGE->set_context($context);
 
-$return_url = optional_param('return_url');
-if (!$return_url)
-{
-    $return_url = '/admin/settings.php?section=blocksettingpanopto';
-}
+$return_url = optional_param('return_url', '/admin/settings.php?section=blocksettingpanopto', PARAM_LOCALURL);
 $urlparams['return_url'] = $return_url;
 
 $PAGE->set_url('/blocks/panopto/provision_course.php', $urlparams);
@@ -78,8 +74,8 @@ else
     $PAGE->set_title($provision_title);
     $PAGE->set_heading($provision_title);
 
-    $course_id_param = optional_param('course_id');
-    if ($course_id_param)
+    $course_id_param = optional_param('course_id', 0, PARAM_INT);
+    if ($course_id_param != 0)
     {
         require_capability('block/panopto:provision_course', $context);
 


### PR DESCRIPTION
As of Moodle 2.2, the optional_param requires the $default and $type variables, and required_param requires $type.
