### PR TITLE
Fix issues shown in Moodle 2.3

### DIFF
--- a/block_panopto.php
+++ b/block_panopto.php
@@ -52,7 +52,7 @@ class block_panopto extends block_base
     }
 
     // Save per-instance config in custom table instead of mdl_block_instance configdata column
-    function instance_config_save($data)
+    function instance_config_save($data, $nolongerused = false)
     {
         global $COURSE;
 

--- a/lib/PanoptoSoapClient.php
+++ b/lib/PanoptoSoapClient.php
@@ -38,7 +38,7 @@ class PanoptoSoapClient extends SoapClient
 	}
 	
 	// Override SOAP action to work around bug in older PHP SOAP versions.
-	function __doRequest($request, $location, $action, $version)
+	function __doRequest($request, $location, $action, $version, $one_way = null)
 	{
 		return parent::__doRequest($request, $location, $this->current_action, $version);
 	}


### PR DESCRIPTION
Moodle 2.3 developer mode now shows all php warnings - these were flagged up during a 2.2 -> 2.3 upgrade.
