### PR TITLE
Allow removal of the Download Recorder links using capabilities

### DIFF
--- a/block_panopto.php
+++ b/block_panopto.php
@@ -215,12 +215,14 @@ class block_panopto extends block_base
 				        								>" . get_string('course_settings', 'block_panopto') . "</a>
 			        							 </div>\n";
                         $system_info = $panopto_data->get_system_info();
-                        $this->content->text .= "<div class='listItem'>
-				        							" . get_string('download_recorder', 'block_panopto') . "
-					        							<span class='nowrap'>
-					        								(<a href='$system_info->RecorderDownloadUrl'>Windows</a>
-								   							| <a href='$system_info->MacRecorderDownloadUrl'>Mac</a>)</span>
-			        							</div>";
+                        if (has_capability('block/panopto:download_recorder', $context)) {
+                            $this->content->text .= "<div class='listItem'>
+                                                        " . get_string('download_recorder', 'block_panopto') . "
+                                                            <span class='nowrap'>
+                                                                (<a href='$system_info->RecorderDownloadUrl'>Windows</a>
+                                                                | <a href='$system_info->MacRecorderDownloadUrl'>Mac</a>)</span>
+                                                    </div>";
+                        }
                     }
                      
                     $this->content->text .= '

--- a/db/access.php
+++ b/db/access.php
@@ -33,5 +33,13 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW
         )
-    )
+    ),
+    'block/panopto:download_recorder' => array(
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_BLOCK,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        )
+    ),
 );


### PR DESCRIPTION
In our institution (Lancaster University), we don't want to show the 'Download Recorder' links at present to all users. The first commit in this patch removes