### PR TITLE
Adding required (in moodle 2.5) block/panopto:addinstance capability

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -33,5 +33,15 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW
         )
+    ),
+    'block/panopto:addinstance' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_BLOCK,
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        ),
+
+        'clonepermissionsfrom' => 'moodle/site:manageblocks'
     )
 );

--- a/version.php
+++ b/version.php
@@ -17,4 +17,4 @@
  * along with the Panopto plugin for Moodle.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$plugin->version = 2012040900;
+$plugin->version = 2013051500;


### PR DESCRIPTION
Lack of block/panopto:addinstance throws a dev warning on 2.5 and above.
