### PR TITLE
Stop the panopto block from being visible on the /my page

### DIFF
--- a/block_panopto.php
+++ b/block_panopto.php
@@ -277,5 +277,12 @@ class block_panopto extends block_base
 
         return $this->content;
     }
+
+    function applicable_formats() {
+        return array(
+            'my' => false,
+            'all' => true,
+        );
+    }
+
 }
-?>


### PR DESCRIPTION
It doesn't make sense to have the panopto block usable on the /my page. This prevents it's use there.
