### PR TITLE
Adding plugin component name to version.php

### DIFF
--- a/version.php
+++ b/version.php
@@ -37,6 +37,7 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->version   = 2013112501;
 $plugin->requires  = 2010112400; // Version 2.0
 $plugin->cron      = 0;
+$plugin->component = 'block_panopto';
 $plugin->maturity  = MATURITY_STABLE;
  
 $plugin->dependencies = array(


### PR DESCRIPTION
I have included the <b><i>$plugin->component</i></b> to <b>version.php</b> file. 
I got an issue when I tried to install the block in my Moodle version 2.4 with simple-space theme. After including the component name in the version file resolved the issue.
