### PR TITLE
fix for Moodle subdirs

### DIFF
--- a/provision_course.php
+++ b/provision_course.php
@@ -58,7 +58,7 @@ if ($course_id_param != 0) {
 
 $PAGE->set_context($context);
 
-$return_url = optional_param('return_url', '/admin/settings.php?section=blocksettingpanopto', PARAM_LOCALURL);
+$return_url = optional_param('return_url', $CFG->wwwroot . '/admin/settings.php?section=blocksettingpanopto', PARAM_LOCALURL);
 
 $urlparams['return_url'] = $return_url;
 


### PR DESCRIPTION
When moodle roots are constructed as www.school.org/moodle panopto returns to www.school.org after provisioning.

With this fix, the actual moodle wwwroot is prepended to the url, fixing the bug.
