### PR TITLE
Panopto throws an undefined property error, hence not concatenating

### DIFF
--- a/block_panopto.php
+++ b/block_panopto.php
@@ -113,7 +113,7 @@ class block_panopto extends block_base {
 
         try {
             if(!$panopto_data->sessiongroup_id) {
-                $this->content->text .= get_string('no_course_selected', 'block_panopto');
+                $this->content->text = get_string('no_course_selected', 'block_panopto');
             } else {
                 // Get course info from SOAP service.
                 $course_info = $panopto_data->get_course();


### PR DESCRIPTION
$this->context->text as it has not been initialized.
This only happens if the moodle site has debugging on which displays PHP errors.
