### PR TITLE
Fix lang stings for capabilities and bump version

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -35,35 +35,31 @@ $capabilities = array(
             'manager' => CAP_ALLOW
         )
     ),
-	'block/panopto:provision_asteacher' => array(
+    'block/panopto:provision_asteacher' => array(
         'captype' => 'write',
         'contextlevel' => CONTEXT_BLOCK,
         'archetypes' => array(
             'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW
         )
     ),
-
-
     'block/panopto:addinstance' => array(
         'riskbitmask' => RISK_SPAM | RISK_XSS,
-
         'captype' => 'write',
         'contextlevel' => CONTEXT_BLOCK,
         'archetypes' => array(
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW
         ),
-
         'clonepermissionsfrom' => 'moodle/site:manageblocks'
     ),
-   'block/panopto:myaddinstance' => array( 'captype' => 'write',
-       'contextlevel' => CONTEXT_SYSTEM, 
-       'archetypes' => array(
-           'user' => CAP_ALLOW
-         ), 
+    'block/panopto:myaddinstance' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM, 
+        'archetypes' => array(
+            'user' => CAP_ALLOW
+        ), 
         'clonepermissionsfrom' => 'moodle/my:manageblocks'
    ) 
 );
-
 /* End of file access.php */

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -22,6 +22,7 @@ $string['panopto:addinstance'] = 'Add a new Panopto block';
 $string['panopto:myaddinstance'] = 'Add a new Panopto block to my page';
 $string['panopto:provision_course'] = 'Provision a course';
 $string['panopto:provision_multiple'] = 'Provision multiple courses at once';
+$string['panopto:provision_asteacher'] = 'Provision as a teacher';
 $string['provision_courses'] = 'Provision Courses';
 $string['provisioncourseselect'] = 'Select Courses to Provision.';
 $string['provisioncourseselect_help'] = 'Multiple selections are possible by Ctrl-clicking (Windows) or Cmd-clicking (Mac).';

--- a/version.php
+++ b/version.php
@@ -34,7 +34,7 @@
  
 defined('MOODLE_INTERNAL') || die();
  
-$plugin->version   = 2014042501;
+$plugin->version   = 2014042502;
 $plugin->requires  = 2010112400; // Version 2.0
 $plugin->cron      = 0;
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
I received the following error on Moodle 2.6.3 with debugging turned on 

```
Invalid get_string() identifier: 'panopto:provision_asteacher' or component 'block_panopto'. Perhaps you are missing $string['panopto:provision_asteacher'] = ''; in /var/www/studysmartstage/acpe/blocks/panopto/lang/en/block_panopto.php?

    line 293 of /lib/classes/string_manager_standard.php: call to debugging()
    line 6839 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
    line 2962 of /lib/accesslib.php: call to get_string()
    line 44 of /admin/tool/capability/index.php: call to get_capability_string()
```

The following commit fixes the language file and also fixes some formatting. The version bump is required to install the lang file.
