### PR TITLE
Move rolling sync to adhoc task

### DIFF
--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -5,85 +5,65 @@ defined('MOODLE_INTERNAL') || die();
 require_once(dirname(__FILE__) . '/../../../config.php');
 require_once(dirname(__FILE__) . '/../lib/panopto_data.php');
 
-class block_panopto_rollingsync{  
-    //Handlers for each different event type
-    
-    
-    public static function enrolmentcreated(\core\event\user_enrolment_created $event){
-        
-        $enrolment_info = block_panopto_rollingsync::get_info_for_enrolment_change($event);
-        //Call to add user
-        $panopto_data_instance = new panopto_data($event->courseid);
-        $panopto_data_instance->add_course_user($enrolment_info['role'], $enrolment_info['userkey']);
-    }
-    
-    public static function enrolmentdeleted(\core\event\user_enrolment_deleted $event){
-        $enrolment_info = block_panopto_rollingsync::get_info_for_enrolment_change($event);
-
-        //Call to remove user
-        $panopto_data_instance = new panopto_data($event->courseid);
-        $panopto_data_instance->remove_course_user($enrolment_info['role'], $enrolment_info['userkey']);
-    }    
-
-    public static function roleadded(\core\event\role_assigned $event){
-        $sgid = panopto_data::get_panopto_course_id($event->courseid);
-        $enrolment_info = block_panopto_rollingsync::get_info_for_enrolment_change($event);
-
-        //Change user's role to new role
-        $panopto_data_instance = new panopto_data($event->courseid);
-        $result = $panopto_data_instance->change_user_role($enrolment_info['role'], $enrolment_info['userkey']);
-        
-    }
-    
-   public static function roledeleted(\core\event\role_unassigned $event){
-
-        $enrolment_info = block_panopto_rollingsync::get_info_for_enrolment_change($event);
-
-        //Change user's role to new role
-        $panopto_data_instance = new panopto_data($event->courseid);
-        $result = $panopto_data_instance->change_user_role($enrolment_info['role'], $enrolment_info['userkey']);
-        
+/**
+ * Handlers for each different event type.
+ */
+class block_panopto_rollingsync
+{
+    /**
+     * Called when an enrolment has been created.
+     */
+    public static function enrolmentcreated(\core\event\user_enrolment_created $event) {
+        $task = new \block_panopto\task\update_user();
+        $task->set_custom_data(array(
+            'courseid' => $event->courseid,
+            'relateduserid' => $event->relateduserid,
+            'contextid' => $event->contextid,
+            'eventtype' => "enrol_add"
+        ));
+        \core\task\manager::queue_adhoc_task($task);
     }
 
-    //Helper functions
-
-    static function get_role_from_context($contextid, $userid){
-        $context = context::instance_by_id($contextid);
-        
-        if(has_capability('block/panopto:provision_aspublisher', $context, $userid)){
-            return "Publisher";
-        }
-        elseif (has_capability('block/panopto:provision_asteacher', $context, $userid)) {
-            return "Creator";
-        }
-        else{
-            return "Viewer";
-        }
+    /**
+     * Called when an enrolment has been deleted.
+     */
+    public static function enrolmentdeleted(\core\event\user_enrolment_deleted $event) {
+        $task = new \block_panopto\task\update_user();
+        $task->set_custom_data(array(
+            'courseid' => $event->courseid,
+            'relateduserid' => $event->relateduserid,
+            'contextid' => $event->contextid,
+            'eventtype' => "enrol_remove"
+        ));
+        \core\task\manager::queue_adhoc_task($task);
     }
 
-    static function get_info_for_enrolment_change($event){
-        global $DB;
-        
-        //Get user's moodleID and use that to find the corresponding Panopto course ID
-        $moodleid = $event->courseid;
-        $panopto_data_instance = new panopto_data($event->courseid);        
-        $panoptoid = $panopto_data_instance->get_panopto_course_id($moodleid);
+    /**
+     * Called when an role has been added.
+     */
+    public static function roleadded(\core\event\role_assigned $event) {
+        $task = new \block_panopto\task\update_user();
+        $task->set_custom_data(array(
+            'courseid' => $event->courseid,
+            'relateduserid' => $event->relateduserid,
+            'contextid' => $event->contextid,
+            'eventtype' => "role"
+        ));
+        \core\task\manager::queue_adhoc_task($task);
+    }
 
-        //relateduserid is moodle id of user whose enrollment is modified
-        $moodleuserid = $event->relateduserid;
-        
-        //db userkey is "[instancename]\\[username]". Get username and use it to create key
-        $username = "";
-        $user = get_complete_user_data('id', $moodleuserid);
-        $username = $user->username;
-        $userkey = $panopto_data_instance->panopto_decorate_username($username);
-
-        //get contextID to determine user's role
-        $contextid = $event->contextid;
-        $role = block_panopto_rollingsync::get_role_from_context($contextid, $moodleuserid);
-        $info = array("role" => $role, "userkey" =>$userkey);
-        
-        return $info;
+    /**
+     * Called when an role has been removed.
+     */
+    public static function roledeleted(\core\event\role_unassigned $event) {
+        $task = new \block_panopto\task\update_user();
+        $task->set_custom_data(array(
+            'courseid' => $event->courseid,
+            'relateduserid' => $event->relateduserid,
+            'contextid' => $event->contextid,
+            'eventtype' => "role"
+        ));
+        \core\task\manager::queue_adhoc_task($task);
     }
 }
 

--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -16,6 +16,10 @@ class block_panopto_rollingsync
     public static function enrolmentcreated(\core\event\user_enrolment_created $event) {
         global $CFG;
 
+        if (\panopto_data::get_panopto_course_id($event->courseid) === false) {
+            return;
+        }
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -36,6 +40,10 @@ class block_panopto_rollingsync
      */
     public static function enrolmentdeleted(\core\event\user_enrolment_deleted $event) {
         global $CFG;
+
+        if (\panopto_data::get_panopto_course_id($event->courseid) === false) {
+            return;
+        }
 
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
@@ -58,6 +66,10 @@ class block_panopto_rollingsync
     public static function roleadded(\core\event\role_assigned $event) {
         global $CFG;
 
+        if (\panopto_data::get_panopto_course_id($event->courseid) === false) {
+            return;
+        }
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -78,6 +90,10 @@ class block_panopto_rollingsync
      */
     public static function roledeleted(\core\event\role_unassigned $event) {
         global $CFG;
+
+        if (\panopto_data::get_panopto_course_id($event->courseid) === false) {
+            return;
+        }
 
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(

--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -14,6 +14,8 @@ class block_panopto_rollingsync
      * Called when an enrolment has been created.
      */
     public static function enrolmentcreated(\core\event\user_enrolment_created $event) {
+        global $CFG;
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -21,13 +23,20 @@ class block_panopto_rollingsync
             'contextid' => $event->contextid,
             'eventtype' => "enrol_add"
         ));
-        \core\task\manager::queue_adhoc_task($task);
+
+        if ($CFG->block_panopto_async_tasks) {
+            \core\task\manager::queue_adhoc_task($task);
+        } else {
+            $task->execute();
+        }
     }
 
     /**
      * Called when an enrolment has been deleted.
      */
     public static function enrolmentdeleted(\core\event\user_enrolment_deleted $event) {
+        global $CFG;
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -35,13 +44,20 @@ class block_panopto_rollingsync
             'contextid' => $event->contextid,
             'eventtype' => "enrol_remove"
         ));
-        \core\task\manager::queue_adhoc_task($task);
+
+        if ($CFG->block_panopto_async_tasks) {
+            \core\task\manager::queue_adhoc_task($task);
+        } else {
+            $task->execute();
+        }
     }
 
     /**
      * Called when an role has been added.
      */
     public static function roleadded(\core\event\role_assigned $event) {
+        global $CFG;
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -49,13 +65,20 @@ class block_panopto_rollingsync
             'contextid' => $event->contextid,
             'eventtype' => "role"
         ));
-        \core\task\manager::queue_adhoc_task($task);
+
+        if ($CFG->block_panopto_async_tasks) {
+            \core\task\manager::queue_adhoc_task($task);
+        } else {
+            $task->execute();
+        }
     }
 
     /**
      * Called when an role has been removed.
      */
     public static function roledeleted(\core\event\role_unassigned $event) {
+        global $CFG;
+
         $task = new \block_panopto\task\update_user();
         $task->set_custom_data(array(
             'courseid' => $event->courseid,
@@ -63,8 +86,11 @@ class block_panopto_rollingsync
             'contextid' => $event->contextid,
             'eventtype' => "role"
         ));
-        \core\task\manager::queue_adhoc_task($task);
+
+        if ($CFG->block_panopto_async_tasks) {
+            \core\task\manager::queue_adhoc_task($task);
+        } else {
+            $task->execute();
+        }
     }
 }
-
-?>

--- a/classes/task/update_user.php
+++ b/classes/task/update_user.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Panopto
+ *
+ * @package    block_panopto
+ * @copyright  2014 Skylar Kelty <S.Kelty@kent.ac.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_panopto\task;
+
+require_once(dirname(__FILE__) . '/../../lib/panopto_data.php');
+
+/**
+ * Panopto "update user" task.
+ */
+class update_user extends \core\task\adhoc_task
+{
+    public function get_component() {
+        return 'block_panopto';
+    }
+
+    public function execute() {
+        $eventdata = (array)$this->get_custom_data();
+
+        $panopto = new \panopto_data($eventdata['courseid']);
+        $enrolmentinfo = $this->get_info_for_enrolment_change($panopto, $eventdata['relateduserid'], $eventdata['contextid']);
+
+        switch ($eventdata['eventtype']) {
+            case 'enrol_add':
+                $panopto->add_course_user($enrolmentinfo['role'], $enrolmentinfo['userkey']);
+            break;
+
+            case 'enrol_remove':
+                $panopto->remove_course_user($enrolmentinfo['role'], $enrolmentinfo['userkey']);
+            break;
+
+            case 'role':
+                $panopto->change_user_role($enrolmentinfo['role'], $enrolmentinfo['userkey']);
+            break;
+        }
+    }
+
+    /**
+     * Return the correct role for a user, given a context.
+     */
+    private function get_role_from_context($contextid, $userid) {
+        $context = \context::instance_by_id($contextid);
+
+        if (has_capability('block/panopto:provision_aspublisher', $context, $userid)) {
+            return "Publisher";
+        } else if (has_capability('block/panopto:provision_asteacher', $context, $userid)) {
+            return "Creator";
+        } else {
+            return "Viewer";
+        }
+    }
+
+    /**
+     * Return user info for this event.
+     */
+    private function get_info_for_enrolment_change($panopto, $relateduserid, $contextid) {
+        global $DB;
+
+        // DB userkey is "[instancename]\\[username]". Get username and use it to create key.
+        $user = get_complete_user_data('id', $relateduserid);
+        $username = $user->username;
+        $userkey = $panopto->panopto_decorate_username($username);
+
+        // Get contextID to determine user's role.
+        $contextid = $contextid;
+        $role = $this->get_role_from_context($contextid, $relateduserid);
+
+        return array(
+            "role" => $role,
+            "userkey" => $userkey
+        );
+    }
+}

--- a/classes/task/update_user.php
+++ b/classes/task/update_user.php
@@ -14,14 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Panopto
- *
- * @package    block_panopto
- * @copyright  2014 Skylar Kelty <S.Kelty@kent.ac.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace block_panopto\task;
 
 require_once(dirname(__FILE__) . '/../../lib/panopto_data.php');

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -60,5 +60,6 @@ $string['show_less'] = 'Show Less';
 $string['role_map_header'] = 'Change Panopto Role Mappings';
 $string['role_map_info_text'] = "Choose which Panopto roles a user's Moodle role will map to. <br> Unmapped roles will be given the 'Viewer' role in Panopto.
  <br> If a role is mapped to both 'Publisher' and 'Creator', 'Publisher' will take precedence.<br><br> ";
+$string['block_panopto_async_tasks'] = 'Asynchronous enrolment sync';
 
 /* End of file block_panopto.php */

--- a/settings.php
+++ b/settings.php
@@ -62,6 +62,15 @@ if ($ADMIN->fulltree) {
         				PARAM_TEXT));
     }
 
+    $settings->add(
+        new admin_setting_configcheckbox(
+            'block_panopto_async_tasks',
+            get_string('block_panopto_async_tasks', 'block_panopto'),
+            '',
+            0
+        )
+    );
+
     $link ='<a href="'.$CFG->wwwroot.'/blocks/panopto/provision_course.php">' . get_string('block_global_add_courses', 'block_panopto') . '</a>';
     $settings->add(new admin_setting_heading('block_panopto_add_courses', '', $link));
 


### PR DESCRIPTION
Having the SOAP calls in the observers means that role/enrolment changes are much slower.
We sync nightly with our student data system, and that can easily pull in 100's or 1000's of enrolment/role changes, this really slows that down.

This makes the observers spawn an adhoc task to deal with the SOAP calls later in cron, which takes the slowdown caused by the api queries away from end-users.