### PR TITLE
Added isset condition

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -23,7 +23,7 @@ defined('MOODLE_INTERNAL') || die;
 include 'version.php';
 global $CFG;
 global $numservers;
-$numservers = $CFG->block_panopto_server_number;
+$numservers = isset($CFG->block_panopto_server_number) ? $CFG->block_panopto_server_number : 1;
 $default = 0;
 if ($ADMIN->fulltree) {
     $_SESSION['numservers'] = $numservers + 1;


### PR DESCRIPTION
Added isset condition to prevent 

Notice: Undefined property: stdClass::$block_panopto_server_number in C:\phpstorm\moodle\blocks\panopto\settings.php on line
 27