### PR TITLE
We do not need to provision the course site

### DIFF
--- a/provision_course.php
+++ b/provision_course.php
@@ -66,7 +66,8 @@ class panopto_provision_form extends moodleform {
         global $aserverarray;
 
         $mform = & $this->_form;
-        $coursesraw = $DB->get_records('course', null, '', 'id, shortname, fullname');
+        $select_query = "id <> 1";
+        $coursesraw = $DB->get_records_select('course', $select_query, null, 'id, shortname, fullname');
         $courses = array();
         if ($coursesraw) {
             foreach ($coursesraw as $course) {


### PR DESCRIPTION
When using the global provision course there is no need to provision the moodle site itself as this ultimately stops the script . 