### PR TITLE
Logging exception to server log and outputting the SOAP error on screen

### DIFF
--- a/lib/panopto_soap_client.php
+++ b/lib/panopto_soap_client.php
@@ -176,7 +176,17 @@ class panopto_soap_client extends soap_client_with_timeout {
         // Store action for use in overridden __doRequest.
         $this->currentaction = "http://services.panopto.com/IClientDataService/$methodname";
         // Make the SOAP call via SoapClient::__soapCall.
-        return parent::__soapCall($methodname, $soapvars);
+        try{
+            return parent::__soapCall($methodname, $soapvars);
+        }
+        catch (Exception $e) {
+            echo "<div style='color:red;'> Error:" . $e->getMessage()."</div>";
+            error_log("Error:" . $e->getMessage());
+            error_log("File: " . $e->getFile());
+            error_log("Line: " . $e->getLine());
+            error_log("Trace: " . $e->getTraceAsString());
+        }
+
     }
     /**
      * Convert an associative array into an array of SoapVars with name $key and value $value.

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,3 @@
-// This file is part of Moodle - http://moodle.org/
-//
-// Moodle is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Moodle is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
-/**
- * @package block_panopto
- * @copyright  Panopto 2009 - 2015 with contributions from Spenser Jones (sjones@ambrose.edu)
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-
-
-/* Provisioning pages */
-
 .block_panopto .courseProvisionResult
 {
     border: solid 1px #C0C0C0;


### PR DESCRIPTION
Logging exception to server log and outputting the SOAP error on screen.This is helpful when global provisioning a lot of courses which continues to provision the remaining ones without killing the script

(cherry picked from commit ad8645c)