### PR TITLE
Increase size of role mapping tables

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="blocks/panopto/db" VERSION="20150115" COMMENT="XMLDB file for Panopto Focus block"
+<XMLDB PATH="blocks/panopto/db" VERSION="20170306" COMMENT="XMLDB file for Panopto Focus block"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
     <TABLE NAME="block_panopto_foldermap" COMMENT="Map Moodle courses to Panopto folders">
-        <FIELDS>
-            <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
-            <FIELD NAME="moodleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of Moodle course."/>
-            <FIELD NAME="panopto_id" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false" COMMENT="Public ID of Panopto folder."/>
-            <FIELD NAME="panopto_server" TYPE="char" LENGTH="64" NOTNULL="true" SEQUENCE="false" COMMENT="Panopto server name for course."/>
-            <FIELD NAME="panopto_app_key" TYPE="char" LENGTH="64" NOTNULL="true" SEQUENCE="false" COMMENT="Panopto application key for server."/>
-            <FIELD NAME="publisher_mapping" TYPE="char" LENGTH="20" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>
-            <FIELD NAME="creator_mapping" TYPE="char" LENGTH="20" NOTNULL="false" DEFAULT="3,4" SEQUENCE="false"/>
-        </FIELDS>
-        <KEYS>
-            <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for test"/>
-        </KEYS>
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table, please edit me"/>
+        <FIELD NAME="moodleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of Moodle course."/>
+        <FIELD NAME="panopto_id" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false" COMMENT="Public ID of Panopto folder."/>
+        <FIELD NAME="panopto_server" TYPE="char" LENGTH="64" NOTNULL="true" SEQUENCE="false" COMMENT="Panopto server name for course."/>
+        <FIELD NAME="panopto_app_key" TYPE="char" LENGTH="64" NOTNULL="true" SEQUENCE="false" COMMENT="Panopto application key for server."/>
+        <FIELD NAME="publisher_mapping" TYPE="char" LENGTH="255" NOTNULL="false" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="creator_mapping" TYPE="char" LENGTH="255" NOTNULL="false" DEFAULT="3,4" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for test"/>
+      </KEYS>
     </TABLE>
     <TABLE NAME="block_panopto_importmap" COMMENT="Map Moodle courses to imported courses">
-        <FIELDS>
-            <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the current import"/>
-            <FIELD NAME="target_moodle_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of the recipient Moodle course for the import."/>
-            <FIELD NAME="import_moodle_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of the imported Moodle course."/>
-        </FIELDS>
-        <KEYS>
-            <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for import map table"/>
-        </KEYS>
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the current import"/>
+        <FIELD NAME="target_moodle_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of the recipient Moodle course for the import."/>
+        <FIELD NAME="import_moodle_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of the imported Moodle course."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for import map table"/>
+      </KEYS>
     </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -155,6 +155,22 @@ function xmldb_block_panopto_upgrade($oldversion = 0) {
         // Panopto savepoint reached.
         upgrade_block_savepoint(true, 2016102709, 'panopto');
     }
+    
+    if ($oldversion < 2017020101) {
+        // Increase size of publisher_mapping and creator_mapping to allow for
+        // more roles to be selected.
+        $table = new xmldb_table('block_panopto_foldermap');
+        $fields = array();
+        $fields[] = new xmldb_field('publisher_mapping', XMLDB_TYPE_CHAR, '255', null, null, null, '1', 'panopto_app_key');
+        $fields[] = new xmldb_field('creator_mapping', XMLDB_TYPE_CHAR, '255', null, null, null, '3,4', 'publisher_mapping');
+        
+        foreach ($fields as $field) {
+            $dbman->change_field_precision($table, $field);            
+        }
+
+        // Panopto savepoint reached.
+        upgrade_block_savepoint(true, 2017020101, 'panopto');        
+    }
 
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2017020100;
+$plugin->version = 2017020101;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;


### PR DESCRIPTION
While testing the Panopto and Moodle integration we were running into problems. It turns out the error is because we had 7 roles selected for the publisher role and 11 roles for the Creator role mapping. But the database table that holds the role mapping is limited to only 20 characters.

This patch increases the size of the role mapping tables, publisher_mapping and creator_mapping, in the block_panopto_foldermap table so that Moodle instances can specify more than 20 characters of role ids.
