### PR TITLE
Added more error info for the block.

### DIFF
--- a/yui/asyncload/asyncload.js
+++ b/yui/asyncload/asyncload.js
@@ -37,7 +37,13 @@ YUI.add('moodle-block_panopto-asyncload',
                                         // Remove loading text.
                                         mynode.removeChild(Y.one('#loading_text'));
                                         // Display error in block.
-                                        mynode.set('innerHTML', o.responseText);
+                                        if(o.responseText == ""){
+                                            mynode.set('innerHTML', "Unknown error occurred.Please refresh the page.If problem persists, contact the administrator. " +
+                                                "Error:"+o.status+" - "+o.statusText);
+                                        }
+                                        else{
+                                            mynode.set('innerHTML', o.responseText);
+                                        }
                                     } catch(err) {
                                         Y.log(err.message);
                                     }


### PR DESCRIPTION
Most of the times there are no errors shown in the o.responseText if there is an error as a result of which the block shows a blank output.It would be very useful to display the status and statustext to the user for admins to further investigate the cause like the one done below. The hardcoded text on line 41 is up for debate. 

