### PR TITLE
2017061400 release candidate

### DIFF
--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -121,6 +121,20 @@ class block_panopto_rollingsync {
     }
 
     /**
+     * Called when a course has been deleted.
+     *
+     * @param \core\event\course_deleted $event
+     */
+    public static function coursedeleted(\core\event\course_deleted $event) {
+        if (!\panopto_data::is_main_block_configured() ||
+            !\panopto_data::has_minimum_version()) {
+            return;
+        }
+
+        \panopto_data::delete_panopto_relation($event->courseid, true);
+    }
+
+    /**
      * Called when a course has been restored (imported/backed up).
      *
      * @param \core\event\course_restored $event

--- a/db/events.php
+++ b/db/events.php
@@ -42,5 +42,9 @@ $observers = array(
     array(
         'eventname' => '\core\event\course_restored',
         'callback' => 'block_panopto_rollingsync::courserestored',
-    )
+    ),
+    array(
+        'eventname' => '\core\event\course_deleted',
+        'callback' => 'block_panopto_rollingsync::coursedeleted',
+    ),
 );

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -111,6 +111,7 @@ $string['provisioncourseselect_help'] = 'Multiple selections are possible by Ctr
 $string['publisher'] = 'Publisher';
 $string['publisher_help'] = 'A Publisher can approve content submitted by Creators';
 $string['publishers'] = 'Publishers';
+$string['removing_invalid_folder_row'] = "Moodle course was deleted from Moodle or the link to Panopto does not contain all of the necessary info to connect to this folder. Moving foldermap entry to old_foldermap for user reference.\n";
 $string['reprovision_course_link_text'] = 'Reprovision Course';
 $string['result'] = 'Result';
 $string['require_panopto_version_title'] = 'Minimum Panopto version required for this version of the Moodle Panopto block';

--- a/lib/panopto_session_soap_client.php
+++ b/lib/panopto_session_soap_client.php
@@ -324,7 +324,6 @@ class panopto_session_soap_client extends SoapClient {
         if ($this->sessionmanagementserviceget->GetFoldersList($folderlistparams)) {
             $retobj = $this->sessionmanagementserviceget->getResult();
             $totalresults = $retobj->GetFoldersListResult->TotalNumberResults;
-            error_log(print_r($totalresults, true));
 
             $folderlist = $retobj->GetFoldersListResult->Results->Folder;
 

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
 
-$plugin->version = 2017061000;
+$plugin->version = 2017061400;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;


### PR DESCRIPTION
Upgrade from version 2017032401 or before, to this version (2017061400) requires the reprovisioning of Panopto course folders. The result is transparent to the end users, but the process itself may take up to a few hours and Moodle becomes inaccessible during that time. Please see Panopto support page (https://support.panopto.com/MoodlePluginUpgrade17) for more information and plan upgrade accordingly.
 
This version of plugin supports (a) Moodle 3.1 or later and (b) Panopto version 5.4.0 or later.
Please upgrade both Moodle and Panopto versions before plugin upgrade.
 
This plugin version has the following improvements.
- improvement to the 2017061000 upgrade process around handling Panopto entries for courses deleted in Moodle.
- When a course linked to Panopto is deleted the code now properly cleans up the link between the Moodle course and Panopto. 