### PR TITLE
2018121000 release candidate.

### DIFF
--- a/classes/task/ensure_category.php
+++ b/classes/task/ensure_category.php
@@ -53,8 +53,6 @@ class ensure_category extends \core\task\adhoc_task {
             
             $targetservers = get_target_panopto_servers();
             foreach ($targetservers as $targetserver) {
-                \panopto_data::print_log(print_r($targetserver, true));
-                
                 $serverpanopto = new \panopto_category_data($categoryid);
                 $serverpanopto->applicationkey = $targetserver->appkey;
                 $serverpanopto->servername = $targetserver->name;

--- a/classes/task/sync_user_login.php
+++ b/classes/task/sync_user_login.php
@@ -46,7 +46,7 @@ class sync_user_login extends \core\task\adhoc_task {
             
             $targetservers = get_target_panopto_servers();
             foreach ($targetservers as $targetserver) {
-                $serverpanopto = new \panopto_data();
+                $serverpanopto = new \panopto_data(null);
                 $serverpanopto->applicationkey = $targetserver->appkey;
                 $serverpanopto->servername = $targetserver->name;
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -62,5 +62,16 @@
             <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for test"/>
         </KEYS>
     </TABLE>
+    <TABLE NAME="block_panopto_categorymap" COMMENT="A list of mapped category folders in Panopto">
+        <FIELDS>
+            <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="id of the table"/>
+            <FIELD NAME="category_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of Moodle category."/>
+            <FIELD NAME="panopto_id" TYPE="char" LENGTH="36" NOTNULL="true" SEQUENCE="false" COMMENT="Public ID of Panopto folder."/>
+            <FIELD NAME="panopto_server" TYPE="char" LENGTH="64" NOTNULL="true" SEQUENCE="false" COMMENT="Panopto server name for that contains folder that matches to this category."/>
+        </FIELDS>
+        <KEYS>
+            <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for test"/>
+        </KEYS>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -24,6 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+$string['add_a_panopto_server'] = 'None - Please add a Panopto server/appkey to continue';
 $string['add_to_panopto'] = 'Sync this course to Panopto';
 $string['api_manager_unavailable'] = 'Unable to create the {$a} manager api client! (Is the Panopto server available, if so are the instance name and application key correct?)';
 $string['application_key'] = 'Application key';
@@ -68,8 +69,8 @@ $string['block_panopto_auto_provision'] = 'Automatically provision newly created
 $string['block_panopto_auto_provision_desc'] = 'Enable this option to automatically provision a Panopto course folder when a course is created.';
 $string['block_panopto_auto_sync_imports'] = 'Automatically grant permissions when importing a course';
 $string['block_panopto_auto_sync_imports_desc'] = 'Enable this option to allow Panopto to automatically grant viewer permissions when importing a course.';
-$string['block_panopto_automatic_operation_target_servers'] = 'Automatic operation target servers';
-$string['block_panopto_automatic_operation_target_servers_desc'] = 'These are the Panopto servers that will be targeted for the \'Automatically provision new courses\', \'Sync user on login\' and \'Enforce category structure\' tasks';
+$string['block_panopto_automatic_operation_target_server'] = 'Automatic operation target server';
+$string['block_panopto_automatic_operation_target_server_desc'] = 'This is the Panopto server that will be targeted for the \'Automatically provision new courses\', \'Sync user on login\' and \'Enforce category structure\' tasks';
 $string['block_panopto_check_server_status'] = 'Check server health before loading block';
 $string['block_panopto_check_server_status_desc'] = 'This checks if the target Panopto server is up at the beginning to avoid possible long timeout calls when the server is unreachable. This is set to false by default because it uses platform / OS dependent feature. It should be set to true only when Panopto support recommends it.';
 $string['block_panopto_creator_mapping'] = 'Creator role mapping';
@@ -105,6 +106,8 @@ $string['block_panopto_wsdl_proxy_host_desc'] = 'The host address used as a prox
 $string['block_panopto_wsdl_proxy_port'] = 'WSDL proxy port';
 $string['block_panopto_wsdl_proxy_port_desc'] = 'The port used as a proxy for any Panopto service WSDL. (Optional)';
 $string['category_branch_ensured'] = 'Categrory branch ensured with the following structure: \n {$a}';
+$string['categories_need_newer_panopto'] = 'Category calls need a Panopto server version of {$a->requiredpanoptoversion} to succeed, the targeted Panopto server\'s version is {$a->activepanoptoversion}.';
+
 $string['cli_category_invalid_arguments'] = 'Please run the command with the following arguments \'build_category_structure.php <panoptoservername> <applicationkey>\'';
 $string['cli_heading_build_category_structure'] = 'Sync all Moodle categories to Panopto';
 $string['completed_recordings'] = 'Completed Recordings';

--- a/lib/block_panopto_lib.php
+++ b/lib/block_panopto_lib.php
@@ -114,12 +114,12 @@ function generate_wsdl_service_params($apiurl) {
 }
 
 /**
- * Returns a list of objects containing valid servername/appkey pairs we are targeting
+ * Returns a list of objects containing valid servername/appkey pairs we are targeting.
  *
  */
 function get_target_panopto_servers() {
     $ret = array();
-    $targetservers = explode(",", get_config('block_panopto', 'automatic_operation_target_servers'));
+    $targetservers = explode(",", get_config('block_panopto', 'automatic_operation_target_server'));
 
     $numservers = get_config('block_panopto', 'server_number');
     $numservers = isset($numservers) ? $numservers : 0;
@@ -174,6 +174,52 @@ function get_panopto_app_key($panoptoservername) {
     }
     
     return null;
+}
+
+/**
+ * Used to instantiate a user soap client for a given instance of panopto_data.
+ * Should be called only the first time a soap client is needed for an instance.
+ *
+ * @param string $username the name of the current user
+ * @param string $servername the name of the active server
+ * @param string $applicationkey the key need for the user to be authenticated
+ */
+function instantiate_panopto_user_soap_client($username, $servername, $applicationkey) {
+    // Compute web service credentials for given user.
+    $apiuseruserkey = panopto_decorate_username($username);
+    $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
+
+    // Instantiate our SOAP client.
+    return new panopto_user_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
+}
+
+/**
+ * Used to instantiate a session soap client for a given instance of panopto_data.
+ *
+ * @param string $username the name of the current user
+ * @param string $servername the name of the active server
+ * @param string $applicationkey the key need for the user to be authenticated
+ */
+function instantiate_panopto_session_soap_client($username, $servername, $applicationkey) {
+    // Compute web service credentials for given user.
+    $apiuseruserkey = panopto_decorate_username($username);
+    $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
+
+    // Instantiate our SOAP client.
+    return new panopto_session_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
+}
+
+/**
+ * Used to instantiate a soap client for calling Panopto's iAuth service.
+ * Should be called only the first time an  auth soap client is needed for an instance.
+ */
+function instantiate_panopto_auth_soap_client($username, $servername, $applicationkey) {
+    // Compute web service credentials for given user.
+    $apiuseruserkey = panopto_decorate_username($username);
+    $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
+
+    // Instantiate our SOAP client.
+    return new panopto_auth_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
 }
 
 /**

--- a/lib/panopto_data.php
+++ b/lib/panopto_data.php
@@ -202,7 +202,7 @@ class panopto_data {
     public function ensure_session_manager() {
         // If no session soap client exists instantiate one.
         if (!isset($this->sessionmanager)) {
-            $this->sessionmanager = self::instantiate_session_soap_client(
+            $this->sessionmanager = instantiate_panopto_session_soap_client(
                 $this->uname,
                 $this->servername,
                 $this->applicationkey
@@ -221,7 +221,7 @@ class panopto_data {
         // If no session soap client exists instantiate one.
         if (!isset($this->authmanager)) {
             // If no auth soap client for this instance, instantiate one.
-            $this->authmanager = self::instantiate_auth_soap_client(
+            $this->authmanager = instantiate_panopto_auth_soap_client(
                 $this->uname,
                 $this->servername,
                 $this->applicationkey
@@ -243,7 +243,7 @@ class panopto_data {
         if (!isset($this->usermanager) || ($this->usermanager->authparam->UserKey !== $this->panopto_decorate_username($usertomanage))) {
 
             // If no auth soap client for this instance, instantiate one.
-            $this->usermanager = self::instantiate_user_soap_client(
+            $this->usermanager = instantiate_panopto_user_soap_client(
                 $usertomanage,
                 $this->servername,
                 $this->applicationkey
@@ -1104,52 +1104,6 @@ class panopto_data {
         }
 
         return array('courses' => $options, 'selected' => $this->sessiongroupid);
-    }
-
-    /**
-     * Used to instantiate a user soap client for a given instance of panopto_data.
-     * Should be called only the first time a soap client is needed for an instance.
-     *
-     * @param string $username the name of the current user
-     * @param string $servername the name of the active server
-     * @param string $applicationkey the key need for the user to be authenticated
-     */
-    public static function instantiate_user_soap_client($username, $servername, $applicationkey) {
-        // Compute web service credentials for given user.
-        $apiuseruserkey = panopto_decorate_username($username);
-        $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
-
-        // Instantiate our SOAP client.
-        return new panopto_user_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
-    }
-
-    /**
-     * Used to instantiate a session soap client for a given instance of panopto_data.
-     *
-     * @param string $username the name of the current user
-     * @param string $servername the name of the active server
-     * @param string $applicationkey the key need for the user to be authenticated
-     */
-    public static function instantiate_session_soap_client($username, $servername, $applicationkey) {
-        // Compute web service credentials for given user.
-        $apiuseruserkey = panopto_decorate_username($username);
-        $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
-
-        // Instantiate our SOAP client.
-        return new panopto_session_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
-    }
-
-    /**
-     * Used to instantiate a soap client for calling Panopto's iAuth service.
-     * Should be called only the first time an  auth soap client is needed for an instance.
-     */
-    public static function instantiate_auth_soap_client($username, $servername, $applicationkey) {
-        // Compute web service credentials for given user.
-        $apiuseruserkey = panopto_decorate_username($username);
-        $apiuserauthcode = panopto_generate_auth_code($apiuseruserkey . '@' . $servername, $applicationkey);
-
-        // Instantiate our SOAP client.
-        return new panopto_auth_soap_client($servername, $apiuseruserkey, $apiuserauthcode);
     }
 
     /**

--- a/settings.php
+++ b/settings.php
@@ -99,28 +99,20 @@ if ($ADMIN->fulltree) {
         );
     }
 
-    // If no Panopto servers are set just make the default value of the target server an empty array with no choices.
-    if (isset($targetserverarray) && !empty($targetserverarray)) {
-        $settings->add(
-            new admin_setting_configmultiselect(
-                'block_panopto/automatic_operation_target_servers',
-                get_string('block_panopto_automatic_operation_target_servers', 'block_panopto'),
-                get_string('block_panopto_automatic_operation_target_servers_desc', 'block_panopto'),
-                array($targetserverarray[0]),
-                $targetserverarray
-            )
-        );
-    } else {
-        $settings->add(
-            new admin_setting_configmultiselect(
-                'block_panopto/automatic_operation_target_servers',
-                get_string('block_panopto_automatic_operation_target_servers', 'block_panopto'),
-                get_string('block_panopto_automatic_operation_target_servers_desc', 'block_panopto'),
-                array(),
-                array()
-            )
-        );
+    // The next setting requires a Panopto server and appkey combo to be properly set.
+    if (!isset($targetserverarray) || empty($targetserverarray)) {
+        $targetserverarray = array(get_string('add_a_panopto_server', 'block_panopto'));
     }
+
+    $settings->add(
+        new admin_setting_configselect(
+            'block_panopto/automatic_operation_target_server',
+            get_string('block_panopto_automatic_operation_target_server', 'block_panopto'),
+            get_string('block_panopto_automatic_operation_target_server_desc', 'block_panopto'),
+            0,
+            $targetserverarray
+        )
+    );
 
     $settings->add(
         new admin_setting_configcheckbox(

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2018113000;
+$plugin->version = 2018121000;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;

--- a/views/failed_to_ensure_branch.html.php
+++ b/views/failed_to_ensure_branch.html.php
@@ -22,8 +22,15 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 ?>
+            <?php if (!$hasvalidpanoptoversion) { ?>
+<div class='block_panopto'>
+    <div class='panoptoProcessInformation'>
+        <div class='value'>
+            <div class='errorMessage'><?php echo get_string('categories_need_newer_panopto', 'block_panopto', $panoptoversioninfo) ?></div>
+            <?php } else { ?>
             <div class='attribute'><?php echo get_string('attribute_ensure_branch_failed', 'block_panopto') ?></div>
             <div class='value'><?php echo get_string('failed_to_ensure_category_branch', 'block_panopto') ?></div>
+            <?php } ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This is the Winter-2018 stable release of the Panopto Generation 2 plug-in for Moodle.

All users who still use Generation 1 plugin (2017032401 or before) must upgrade to this version before March 15, 2019. Panopto will stop working with Generation 1 at that time.
Upgrade from Generation 1 plugin (2017032401 or before) to this version requires an additional operation after plugin update. Please see this Panopto support page  for more information.

This version of plugin supports (a) Moodle 3.1, 3.4, and 3.5, and (b) Panopto version 5.6.0 or later.
Panopto will soon test this with Moodle 3.6 and post the results to this page when testing completes.

Below is the list of updates from the previous stable release (2018070900).
- New feature to mirror Moodle category structure to Panopto course folders. This feature is available with Panopto 6.0 and later.
- Add a new setting to select the target Panopto server for the automatic provisioning of new courses, synchronizing permissions on login, and synchronizing categories when created or moved. In prior version of plug-in, the target was always the first server in the list.
- Removed the logic to reprovision all courses in periodically scheduled job (cron job) which is not needed anymore.
- Fixed misspellings in privacy declaration.
- Fixed an issue where plug-in may not work correctly with PHP 7.1.
- Fixed an issue with service calls from the Moodle plug-in to the Panopto server where some calls did not happen over HTTPS.
- Fixed an issue where the “Reinitialize all imports” button would not correctly function if a course had more than one import associated with it.

This plug-in added new settings and a new button: 
- The first setting allows admins to enforce Moodle category structure on Panopto folders. This is off by default.
- The second setting allows mirroring of the parent category folders (up to the root category) when a new course is successfully provisioned in Moodle. This is off by default.
- The new link "Sync all Moodle categories" creates and updates Panopto folder tree which reflects all categories in Moodle.
