### PR TITLE
2019081200 release code.

### DIFF
--- a/SSO.php
+++ b/SSO.php
@@ -33,7 +33,12 @@ require_once($CFG->libdir . '/weblib.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');
 
 $servername = required_param('serverName', PARAM_HOST);
-$callbackurl = urldecode(required_param('callbackURL', PARAM_URL));
+$callbackurl = required_param('callbackURL', PARAM_URL);
+
+if (strpos($callbackurl, 'http%') !== false 
+ || strpos($callbackurl, 'https%') !== false) {
+    $callbackurl = urldecode($callbackurl);
+}
 
 // A float doesn't have the required precision.
 $expiration = preg_replace('/[^0-9\.]/', '', required_param('expiration', PARAM_RAW));

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -10,6 +10,12 @@ if (interface_exists('\core_privacy\local\request\userlist')) {
     interface my_userlist extends \core_privacy\local\request\userlist{}
 } else {
     interface my_userlist {};
+} 
+
+if (interface_exists('\core_privacy\local\request\core_userlist_provider')) {
+    interface my_userlist_provider extends \core_privacy\local\request\core_userlist_provider{}
+} else {
+    interface my_userlist_provider {};
 }
 
 if (interface_exists('\core_privacy\local\request\core_user_data_provider')) {
@@ -17,13 +23,14 @@ if (interface_exists('\core_privacy\local\request\core_user_data_provider')) {
 } else {
     interface my_userdataprovider {};
 }
- 
+
 class provider implements 
         // This plugin does store personal user data.
         \core_privacy\local\metadata\provider,
         \core_privacy\local\request\data_provider,
         \core_privacy\local\request\plugin\provider,
         my_userdataprovider,
+        my_userlist_provider,
         my_userlist {
     
     public static function get_metadata(collection $collection) : collection {

--- a/lib/panopto_data.php
+++ b/lib/panopto_data.php
@@ -90,6 +90,11 @@ class panopto_data {
     public $uname;
 
     /**
+     * @var int $maxloglength the maximum length we will allow logs to be when adding a log to Panopto.
+     */
+    private static $maxloglength = 1500;
+
+    /**
      * @var int $requireversion Panopto only supports versions of Moodle newer than v2.7(2014051200).
      */
     private static $requiredversion = 2014051200;
@@ -1390,6 +1395,8 @@ class panopto_data {
 
     public static function print_log($logmessage) {
         global $CFG;
+
+        $logmessage = substr($logmessage, 0, self::$maxloglength);
 
         if (get_config('block_panopto', 'print_log_to_file')) {
             file_put_contents($CFG->dirroot . '/PanoptoLogs.txt', $logmessage . "\n", FILE_APPEND);

--- a/lib/panopto_session_soap_client.php
+++ b/lib/panopto_session_soap_client.php
@@ -163,7 +163,7 @@ class panopto_session_soap_client extends SoapClient {
             $retobj = $this->sessionmanagementserviceprovision->getResult();
             $ret = $retobj->ProvisionExternalCourseWithRolesResult;
         } else {
-            $this->handle_provisioning_error('SessionManagementServiceProvision::ProvisionExternalCourseWithRoles');
+            $this->handle_provisioning_error($this->sessionmanagementserviceprovision->getLastError()['SessionManagementServiceProvision::ProvisionExternalCourseWithRoles']);
         }
 
         return $ret;
@@ -202,7 +202,7 @@ class panopto_session_soap_client extends SoapClient {
             // We do not support multiple folders per course in Moodle atm so we can assume 1 result.
             $ret = $retobj->SetExternalCourseAccessForRolesResult->Folder[0];
         } else {
-            $this->handle_provisioning_error('SessionManagementServiceSet::SetExternalCourseAccessForRoles');
+            $this->handle_provisioning_error($this->sessionmanagementserviceset->getLastError()['SessionManagementServiceSet::SetExternalCourseAccessForRoles']);
         }
 
         return $ret;

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2019070100;
+$plugin->version = 2019081200;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;


### PR DESCRIPTION
This is an optional version of the Panopto plug-in for Moodle. Update to this version if you are affected by any of the problems described below.
This version supports (a) Moodle 3.5, 3.6, and 3.7, and (b) Panopto version 5.6.0 or later.

- Fixed an issue where extremely long error log was generated.
- Fixed an issue where users could get directed to their personal folder instead of the course folder when using a Panopto button plug-in while not logged into Panopto.
- Fixed an issue where error log of provisioning courses may have had wrong information.
- Updated the privacy provider to support phpunit privacy test. Note that the handling of privacy is unchanged by this version.