### PR TITLE
session_soap_client: Remove undefined returns

### DIFF
--- a/lib/panopto_session_soap_client.php
+++ b/lib/panopto_session_soap_client.php
@@ -287,12 +287,10 @@ class panopto_session_soap_client extends SoapClient {
             $retobj = $this->sessionmanagementserviceget->getResult();
             return $retobj->GetFoldersByExternalIdResult->Folder[0];
         } else {
-            $this->handle_error(
+            return $this->handle_error(
                 $this->sessionmanagementserviceget->getLastError()['SessionManagementServiceGet::GetFoldersByExternalId']
             );
         }
-
-        return $ret;
     }
 
     /** 
@@ -587,8 +585,6 @@ class panopto_session_soap_client extends SoapClient {
                 $this->sessionmanagementserviceget->getLastError()['SessionManagementServiceGet::GetRecorderDownloadUrls']
             );
         }
-
-        return $ret;
     }
 
     private function handle_error($lasterror) {


### PR DESCRIPTION
- Two `return $ret;` lines were left over
- One `handle_error` needed to be returned