### PR TITLE
Fix database index clash preventing install

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -33,7 +33,7 @@
         </KEYS>
         <INDEXES>
             <INDEX NAME="mdl_blocpanoimpo_tar_ix" UNIQUE="false" FIELDS="target_moodle_id" COMMENT="index on the import target course id"/>
-            <INDEX NAME="mdl_blocpanoimpo_tar_ix" UNIQUE="false" FIELDS="import_moodle_id" COMMENT="index on the imported course id"/>
+            <INDEX NAME="mdl_blocpanoimpo_imp_ix" UNIQUE="false" FIELDS="import_moodle_id" COMMENT="index on the imported course id"/>
         </INDEXES>
     </TABLE>
     <TABLE NAME="block_panopto_creatormap" COMMENT="a table that maps Moodle roles to the creator capability when provisioning to Panopto">

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -336,7 +336,7 @@ function xmldb_block_panopto_upgrade($oldversion = 0) {
 
         if ($dbman->table_exists($importmaptable)) {
             $targetidindex = new xmldb_index('mdl_blocpanoimpo_tar_ix', XMLDB_INDEX_NOTUNIQUE, array('target_moodle_id'), array());
-            $importidindex = new xmldb_index('mdl_blocpanoimpo_tar_ix', XMLDB_INDEX_NOTUNIQUE, array('import_moodle_id'), array());
+            $importidindex = new xmldb_index('mdl_blocpanoimpo_imp_ix', XMLDB_INDEX_NOTUNIQUE, array('import_moodle_id'), array());
             $dbman->add_index($importmaptable, $targetidindex);
             $dbman->add_index($importmaptable, $importidindex);
         } else {


### PR DESCRIPTION
You can't have two identical names on different indexes, or the install will fail. This pull request renames the index for `import_moodle_id` to `mdl_blocpanoimpo_imp_ix`.