### PR TITLE
2023012400 release code

### DIFF
--- a/SSO.php
+++ b/SSO.php
@@ -24,7 +24,12 @@
 
 // This can't be defined Moodle internal because it is called from Panopto to authorize login.
 
-require_once(dirname(__FILE__) . '/../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/weblib.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');
 

--- a/build_category_structure.php
+++ b/build_category_structure.php
@@ -22,7 +22,12 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(__FILE__) . '/../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_build_category_structure_form.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');

--- a/classes/categorytasks.php
+++ b/classes/categorytasks.php
@@ -24,9 +24,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-// No login check is expected since we can run this from console.
-// @codingStandardsIgnoreLine
-require_once(dirname(__FILE__) . '/../../../config.php');
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../config.php');
+}
 require_once(dirname(__FILE__) . '/../lib/panopto_data.php');
 
 /**

--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -25,9 +25,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-// No login check is expected since we can run this from console.
-// @codingStandardsIgnoreLine
-require_once(dirname(__FILE__) . '/../../../config.php');
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../config.php');
+}
 require_once(dirname(__FILE__) . '/../lib/panopto_data.php');
 require_once(dirname(__FILE__) . '/../lib/lti/panoptoblock_lti_utility.php');
 require_once($CFG->libdir . '/pagelib.php');

--- a/lib/cli/build_category_structure_cli.php
+++ b/lib/cli/build_category_structure_cli.php
@@ -28,7 +28,12 @@
 
 define('CLI_SCRIPT', true);
 
-require_once(dirname(__FILE__) . '/../../../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../../config.php');
+}
 require_once(dirname(__FILE__) . '/../panopto_category_data.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/formslib.php');

--- a/lib/cli/remove_all_panopto_adhoc_tasks.php
+++ b/lib/cli/remove_all_panopto_adhoc_tasks.php
@@ -26,7 +26,12 @@
 
 define('CLI_SCRIPT', true);
 
-require_once(dirname(__FILE__) . '/../../../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../../config.php');
+}
 require_once(dirname(__FILE__) . '/../panopto_data.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/formslib.php');

--- a/lib/cli/rename_all_folders_cli.php
+++ b/lib/cli/rename_all_folders_cli.php
@@ -29,7 +29,12 @@
 
 define('CLI_SCRIPT', true);
 
-require_once(dirname(__FILE__) . '/../../../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../../config.php');
+}
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/../panopto_data.php');

--- a/lib/cli/upgrade_all_folders_cli.php
+++ b/lib/cli/upgrade_all_folders_cli.php
@@ -29,7 +29,12 @@
 
 define('CLI_SCRIPT', true);
 
-require_once(dirname(__FILE__) . '/../../../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../../config.php');
+}
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/../panopto_data.php');

--- a/lib/lti/auth.php
+++ b/lib/lti/auth.php
@@ -22,7 +22,12 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(__FILE__) . '/../../../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../../../config.php');
+}
 require_once($CFG->dirroot . '/mod/lti/locallib.php');
 require_once($CFG->libdir . '/weblib.php');
 require_once(dirname(__FILE__) . '/panoptoblock_lti_utility.php');

--- a/lib/panopto_category_data.php
+++ b/lib/panopto_category_data.php
@@ -23,6 +23,11 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/dmllib.php');
 require_once(dirname(__FILE__) . '/block_panopto_lib.php');
 require_once(dirname(__FILE__) . '/panopto_session_soap_client.php');

--- a/lib/panopto_data.php
+++ b/lib/panopto_data.php
@@ -23,6 +23,11 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once('../../config.php');
+}
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->libdir . '/dmllib.php');
 require_once($CFG->libdir .'/filelib.php');

--- a/panopto_content.php
+++ b/panopto_content.php
@@ -25,7 +25,12 @@
 define('AJAX_SCRIPT', true);
 define('READ_ONLY_SESSION', true);
 
-require_once(dirname(__FILE__) . '/../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');
 
 try {

--- a/provision_course.php
+++ b/provision_course.php
@@ -21,7 +21,13 @@
  * @copyright  Panopto 2009 - 2016 /With contributions from Spenser Jones (sjones@ambrose.edu)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../config.php');
+
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_provision_form.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');

--- a/provision_course_internal.php
+++ b/provision_course_internal.php
@@ -22,7 +22,12 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(__FILE__) . '/../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_provision_course_form.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');

--- a/reinitialize_imports.php
+++ b/reinitialize_imports.php
@@ -21,7 +21,13 @@
  * @copyright  Panopto 2020
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../config.php');
+
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');
 require_once($CFG->libdir . '/formslib.php');
 

--- a/rename_all_folders.php
+++ b/rename_all_folders.php
@@ -21,7 +21,13 @@
  * @copyright  Panopto 2020
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../config.php');
+
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_rename_all_folders_form.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,11 @@
  */
 defined('MOODLE_INTERNAL') || die;
 
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once(dirname(__FILE__) . '/classes/admin/trim_configtext.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');
 

--- a/unprovision_course.php
+++ b/unprovision_course.php
@@ -21,7 +21,13 @@
  * @copyright  Panopto 2020
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../config.php');
+
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_unprovision_form.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');

--- a/unprovision_course_internal.php
+++ b/unprovision_course_internal.php
@@ -22,7 +22,12 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(__FILE__) . '/../../config.php');
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_unprovision_course_form.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');

--- a/upgrade_all_folders.php
+++ b/upgrade_all_folders.php
@@ -21,7 +21,13 @@
  * @copyright  Panopto 2009 - 2017
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(dirname(__FILE__) . '/../../config.php');
+
+// @codingStandardsIgnoreLine
+global $CFG;
+if (empty($CFG)) {
+    // @codingStandardsIgnoreLine
+    require_once(dirname(__FILE__) . '/../../config.php');
+}
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_upgrade_all_folders_form.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2022122000;
+$plugin->version = 2023012400;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires  = 2014051200;


### PR DESCRIPTION
This is the latest beta release for the Panopto Moodle plug-in. Use this beta version if you are affected by any of the problems described below.

This version supports (a) Moodle 3.9, 3.11, 4.0 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Below is the list of updates from the previous stable release (2022122000).
 - Fixed a rare issue that could cause the Moodle block to throw an error due to being unable to find the global configuration file object.
