### PR TITLE
2023031400 release code.

### DIFF
--- a/SSO.php
+++ b/SSO.php
@@ -136,7 +136,7 @@ if ($callbackverified) {
         $responseparamsencoded =
             'serverName=' . $servername . '&externalUserKey=' . urlencode($userkey) . '&expiration=' . $expiration;
 
-        $fullreturnurl = !empty($returnurl) ? '&ReturnUrl=' . $returnurl . $fragment : "";
+        $fullreturnurl = !empty($returnurl) ? '&ReturnUrl=' . urlencode($returnurl) . $fragment : "";
         $separator = (strpos($url, '?') ? '&' : '?');
         $redirecturl = $url . $separator . $responseparamsencoded . '&authCode=' . $responseauthcode . $fullreturnurl;
 

--- a/block_panopto.php
+++ b/block_panopto.php
@@ -162,7 +162,7 @@ class block_panopto extends block_base {
                                     null,
                                     true);
 
-        $this->content->text  = html_writer::tag('div', "<font id='loading_text'>" .
+        $this->content->text = html_writer::tag('div', "<font id='loading_text'>" .
             get_string('fetching_content', 'block_panopto') . '</font>', $params);
 
         $this->content->text .= '<script type="text/javascript">' .

--- a/lib/lti/panoptoblock_lti_utility.php
+++ b/lib/lti/panoptoblock_lti_utility.php
@@ -497,9 +497,10 @@ class panoptoblock_lti_utility {
      * @throws moodle_exception When the LTI tool type does not exist.`
      * @throws coding_exception For invalid media type and presentation target parameters.
      */
-    public static function build_content_item_selection_request($id, $course, moodle_url $returnurl, $title = '', $text = '', $mediatypes = [],
-                                                      $presentationtargets = [], $autocreate = false, $multiple = true,
-                                                      $unsigned = false, $canconfirm = false, $copyadvice = false, $nonce = '', $pluginname = '') {
+    public static function build_content_item_selection_request($id, $course, moodle_url $returnurl, $title = '', $text = '',
+                                                      $mediatypes = [], $presentationtargets = [], $autocreate = false,
+                                                      $multiple = true, $unsigned = false, $canconfirm = false,
+                                                      $copyadvice = false, $nonce = '', $pluginname = '') {
         global $USER, $CFG;
         require_once($CFG->dirroot . '/mod/lti/locallib.php');
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2023012400;
+$plugin->version = 2023031400;
 
 // Requires this Moodle version - 2.7.
-$plugin->requires  = 2014051200;
+$plugin->requires = 2014051200;
 $plugin->cron = 0;
 $plugin->component = 'block_panopto';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This is the current stable release version of the Panopto plug-in for Moodle. It is recommended that customers update to this version of the block.

This version supports (a) Moodle 3.9, 3.11, 4.0, 4.1 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Below is the list of updates from the previous beta release (2023012400).
- Added support for Moodle 4.1
- Fixed an issue that could result in users clicking on a link to view a course folder from Moodle instead being redirected to their home page.
