### PR TITLE
2023091800 release code

### DIFF
--- a/lib/AuthManagement/AuthManagementWsdlClass.php
+++ b/lib/AuthManagement/AuthManagementWsdlClass.php
@@ -640,7 +640,8 @@ class AuthManagementWsdlClass extends stdClass implements ArrayAccess,Iterator,C
      * @uses AuthManagementWsdlClass::offsetGet()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->offsetGet($this->internArrayToIterateOffset);
     }
@@ -678,7 +679,8 @@ class AuthManagementWsdlClass extends stdClass implements ArrayAccess,Iterator,C
      * @uses AuthManagementWsdlClass::getInternArrayToIterateOffset()
      * @return mixed
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return $this->getInternArrayToIterateOffset();
     }
@@ -777,7 +779,8 @@ class AuthManagementWsdlClass extends stdClass implements ArrayAccess,Iterator,C
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return $this->offsetExists($_offset)?$this->internArrayToIterate[$_offset]:null;
     }

--- a/lib/SessionManagement/Array/Context/SessionManagementStructArrayOfFolderWithExternalContext.php
+++ b/lib/SessionManagement/Array/Context/SessionManagementStructArrayOfFolderWithExternalContext.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfFolderWithExternalContext extends SessionMan
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfFolderWithExternalContext extends SessionMan
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Folder/SessionManagementStructArrayOfExtendedFolder.php
+++ b/lib/SessionManagement/Array/Folder/SessionManagementStructArrayOfExtendedFolder.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfExtendedFolder extends SessionManagementWsdl
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfExtendedFolder extends SessionManagementWsdl
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Folder/SessionManagementStructArrayOfFolder.php
+++ b/lib/SessionManagement/Array/Folder/SessionManagementStructArrayOfFolder.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfFolder extends SessionManagementWsdlClass
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfFolder extends SessionManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Note/SessionManagementStructArrayOfNote.php
+++ b/lib/SessionManagement/Array/Note/SessionManagementStructArrayOfNote.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfNote extends SessionManagementWsdlClass
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfNote extends SessionManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/OfExternalHierarchyInfo/SessionManagementStructArrayOfExternalHierarchyInfo.php
+++ b/lib/SessionManagement/Array/OfExternalHierarchyInfo/SessionManagementStructArrayOfExternalHierarchyInfo.php
@@ -79,7 +79,8 @@ class SessionManagementStructArrayOfExternalHierarchyInfo extends SessionManagem
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -117,7 +118,8 @@ class SessionManagementStructArrayOfExternalHierarchyInfo extends SessionManagem
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Ofguid/SessionManagementStructArrayOfguid.php
+++ b/lib/SessionManagement/Array/Ofguid/SessionManagementStructArrayOfguid.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfguid extends SessionManagementWsdlClass
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfguid extends SessionManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Ofstring/SessionManagementStructArrayOfstring.php
+++ b/lib/SessionManagement/Array/Ofstring/SessionManagementStructArrayOfstring.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfstring extends SessionManagementWsdlClass
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfstring extends SessionManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Role/SessionManagementStructArrayOfAccessRole.php
+++ b/lib/SessionManagement/Array/Role/SessionManagementStructArrayOfAccessRole.php
@@ -80,7 +80,8 @@ class SessionManagementStructArrayOfAccessRole extends SessionManagementWsdlClas
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -118,7 +119,8 @@ class SessionManagementStructArrayOfAccessRole extends SessionManagementWsdlClas
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Session/SessionManagementStructArrayOfSession.php
+++ b/lib/SessionManagement/Array/Session/SessionManagementStructArrayOfSession.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfSession extends SessionManagementWsdlClass
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfSession extends SessionManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Settings/SessionManagementStructArrayOfFolderAvailabilitySettings.php
+++ b/lib/SessionManagement/Array/Settings/SessionManagementStructArrayOfFolderAvailabilitySettings.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfFolderAvailabilitySettings extends SessionMa
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfFolderAvailabilitySettings extends SessionMa
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/Settings/SessionManagementStructArrayOfSessionAvailabilitySettings.php
+++ b/lib/SessionManagement/Array/Settings/SessionManagementStructArrayOfSessionAvailabilitySettings.php
@@ -81,7 +81,8 @@ class SessionManagementStructArrayOfSessionAvailabilitySettings extends SessionM
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class SessionManagementStructArrayOfSessionAvailabilitySettings extends SessionM
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/Array/State/SessionManagementStructArrayOfSessionState.php
+++ b/lib/SessionManagement/Array/State/SessionManagementStructArrayOfSessionState.php
@@ -80,7 +80,8 @@ class SessionManagementStructArrayOfSessionState extends SessionManagementWsdlCl
      * @see SessionManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -118,7 +119,8 @@ class SessionManagementStructArrayOfSessionState extends SessionManagementWsdlCl
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/SessionManagement/SessionManagementWsdlClass.php
+++ b/lib/SessionManagement/SessionManagementWsdlClass.php
@@ -639,7 +639,8 @@ class SessionManagementWsdlClass extends stdClass implements ArrayAccess,Iterato
      * @uses SessionManagementWsdlClass::offsetGet()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->offsetGet($this->internArrayToIterateOffset);
     }
@@ -677,7 +678,8 @@ class SessionManagementWsdlClass extends stdClass implements ArrayAccess,Iterato
      * @uses SessionManagementWsdlClass::getInternArrayToIterateOffset()
      * @return int
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return $this->getInternArrayToIterateOffset();
     }
@@ -776,7 +778,8 @@ class SessionManagementWsdlClass extends stdClass implements ArrayAccess,Iterato
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return $this->offsetExists($_offset)?$this->internArrayToIterate[$_offset]:null;
     }

--- a/lib/UserManagement/Array/Group/UserManagementStructArrayOfGroup.php
+++ b/lib/UserManagement/Array/Group/UserManagementStructArrayOfGroup.php
@@ -81,7 +81,8 @@ class UserManagementStructArrayOfGroup extends UserManagementWsdlClass
      * @see UserManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class UserManagementStructArrayOfGroup extends UserManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/UserManagement/Array/Ofguid/UserManagementStructArrayOfguid.php
+++ b/lib/UserManagement/Array/Ofguid/UserManagementStructArrayOfguid.php
@@ -81,7 +81,8 @@ class UserManagementStructArrayOfguid extends UserManagementWsdlClass
      * @see UserManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class UserManagementStructArrayOfguid extends UserManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/UserManagement/Array/Ofstring/UserManagementStructArrayOfstring.php
+++ b/lib/UserManagement/Array/Ofstring/UserManagementStructArrayOfstring.php
@@ -81,7 +81,8 @@ class UserManagementStructArrayOfstring extends UserManagementWsdlClass
      * @see UserManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class UserManagementStructArrayOfstring extends UserManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/UserManagement/Array/User/UserManagementStructArrayOfUser.php
+++ b/lib/UserManagement/Array/User/UserManagementStructArrayOfUser.php
@@ -81,7 +81,8 @@ class UserManagementStructArrayOfUser extends UserManagementWsdlClass
      * @see UserManagementWsdlClass::current()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return parent::current();
     }
@@ -119,7 +120,8 @@ class UserManagementStructArrayOfUser extends UserManagementWsdlClass
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return parent::offsetGet($_offset);
     }

--- a/lib/UserManagement/UserManagementWsdlClass.php
+++ b/lib/UserManagement/UserManagementWsdlClass.php
@@ -634,7 +634,8 @@ class UserManagementWsdlClass extends stdClass implements ArrayAccess,Iterator,C
      * @uses UserManagementWsdlClass::offsetGet()
      * @return mixed
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return $this->offsetGet($this->internArrayToIterateOffset);
     }
@@ -771,7 +772,8 @@ class UserManagementWsdlClass extends stdClass implements ArrayAccess,Iterator,C
      * @param int $_offset
      * @return mixed
      */
-    public function offsetGet($_offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($_offset)
     {
         return $this->offsetExists($_offset)?$this->internArrayToIterate[$_offset]:null;
     }

--- a/lib/panopto_user_soap_client.php
+++ b/lib/panopto_user_soap_client.php
@@ -149,9 +149,19 @@ class panopto_user_soap_client extends PanoptoTimeoutSoapClient {
         if ($this->usermanagementserviceget->GetUserByKey($getuserbykeyparams)) {
             $result = $this->usermanagementserviceget->getResult()->GetUserByKeyResult;
         } else {
-            $lasterror = $this->usermanagementserviceget->getLastError()['UserManagementServiceGet::GetUserByKey'];
-            \panopto_data::print_log(var_export($lasterror, true));
-            throw $lasterror;
+            // Try again in case if username is unified i.e unified\user, but user from moodle DB is still server\user.
+            $username = preg_replace('/^[^\\\\]*\\\\/', 'unified\\', $userkey);
+            $getuserbykeyparams = new UserManagementStructGetUserByKey(
+                $this->authparam,
+                $username
+            );
+            if ($this->usermanagementserviceget->GetUserByKey($getuserbykeyparams)) {
+                $result = $this->usermanagementserviceget->getResult()->GetUserByKeyResult;
+            } else {
+                $lasterror = $this->usermanagementserviceget->getLastError()['UserManagementServiceGet::GetUserByKey'];
+                \panopto_data::print_log(var_export($lasterror, true));
+                throw $lasterror;
+            }
         }
         return $result;
     }

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2023083100;
+$plugin->version = 2023091800;
 
 // Requires this Moodle version - 2.7.
 $plugin->requires = 2014051200;


### PR DESCRIPTION
This is the current stable release version of the Panopto plug-in for Moodle. It is recommended that customers update to this version of the block.

This version supports (a) Moodle 3.9, 3.11, 4.0, 4.1, 4.2 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Below is the list of updates from the previous stable release (2023091800).
- Fixed an issue that could cause `unified users` to fail to login or provision new courses using the block
