### PR TITLE
check the assign permissions instead of assignment

### DIFF
--- a/lib/lti/panoptoblock_lti_utility.php
+++ b/lib/lti/panoptoblock_lti_utility.php
@@ -728,7 +728,7 @@ class panoptoblock_lti_utility {
     public static function is_active_user_enrolled($targetcontext) {
         global $USER;
 
-        return is_enrolled($targetcontext, $USER, 'mod/assignment:submit');
+        return is_enrolled($targetcontext, $USER, 'mod/assign:submit');
     }
 
     /**


### PR DESCRIPTION
Student permissions fail on insert because mod/assignment was removed in Moodle 4.2