### PR TITLE
2024070900 release code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description
+
+
+## Testing
+<!-- How and what have you tested? What needs later verification? -->
+
+
+## Jira Link
+<!-- E.g. PC-### (link to Jira will populate automatically). Optional and Jira# must still be added to the PR title. -->

--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -31,17 +31,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.0'
+          - php: '8.1'
             moodle-branch: 'master'
             database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_400_STABLE'
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
             database: 'mariadb'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_311_STABLE'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_402_STABLE'
             database: 'pgsql'
-          - php: '7.4'
-            moodle-branch: 'MOODLE_39_STABLE'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
             database: 'mariadb'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Panopto plugin for Moodle 2
+# Panopto plugin for Moodle
 
 ## What is it?
 
-This is a block for Moodle 2, that allows courses in Moodle to link directly to Panopto folders, and to display recordings in the sidebar. It also allows for SSO between Moodle and Panopto, and automatically syncs user permissions between both systems.
+This is a block for Moodle, that allows courses in Moodle to link directly to Panopto folders, and to display recordings in the sidebar. It also allows for SSO between Moodle and Panopto, and automatically syncs user permissions between both systems.
 
 ## Credits
 
@@ -12,15 +12,9 @@ The original Panopto plugin was written by Panopto for Moodle 1.9 and earlier. I
 
 Fork the block, fix a bug or add a new feature, and send us a pull-request. Or, if you're not a developer, but you've found a bug, add it to our [issue tracker](https://github.com/Panopto/Moodle-2.0-Plugin-for-Panopto/issues).
 
-## To do:
-* Move language-specific strings into lang/en/block_panopto.php
-* * lib/panopto_data.php
-* * SSO.php
-* * views/provisioned_course.html.php
-
 ## Copyright
 
- Copyright Panopto 2009 - 2018 / With contributions from Spenser Jones (sjones@ambrose.edu), Hittesh Ahuja, and Tim Lock
+Copyright Panopto 2009 - 2024 / With contributions from Spenser Jones (sjones@ambrose.edu), Hittesh Ahuja, and Tim Lock
 
 ## License
 

--- a/classes/rollingsync.php
+++ b/classes/rollingsync.php
@@ -140,8 +140,9 @@ class block_panopto_rollingsync {
      * @param \core\event\course_restored $event
      */
     public static function courserestored(\core\event\course_restored $event) {
-        if (!\panopto_data::is_main_block_configured() ||
-            !\panopto_data::has_minimum_version()) {
+        if (   !\panopto_data::is_main_block_configured()
+            || !\panopto_data::has_minimum_version()
+            || \panopto_data::is_block_disabled()) {
             return;
         }
 

--- a/lib/panopto_category_data.php
+++ b/lib/panopto_category_data.php
@@ -52,12 +52,22 @@ class panopto_category_data {
     private $moodlecategoryid;
 
     /**
-     * @var string $servername
+     * @var int $sessiongroupid The id of the session group.
+     */
+    private $sessiongroupid;
+
+    /**
+     * @var string $uname The username of the current user.
+     */
+    private $uname;
+
+    /**
+     * @var string $servername  The server name.
      */
     private $servername;
 
     /**
-     * @var int $applicationkey
+     * @var int $applicationkey The application key.
      */
     private $applicationkey;
 
@@ -259,7 +269,9 @@ class panopto_category_data {
                 $currentcategory = $DB->get_record('course_categories', ['id' => $targetcategory->parent]);
 
                 while (isset($currentcategory) && !empty($currentcategory)) {
-                    $currentcategoryname = !empty(trim($currentcategory->name)) ? $currentcategory->name : $currentcategory->id;
+                    $currentcategoryname = !empty(trim($currentcategory->name))
+                        ? $multilanguagefilter->filter($currentcategory->name)
+                        : $currentcategory->id;
 
                     $categoryheirarchy[] = new SessionManagementStructExternalHierarchyInfo(
                         false,

--- a/lib/panopto_data.php
+++ b/lib/panopto_data.php
@@ -1201,6 +1201,22 @@ class panopto_data {
     }
 
     /**
+     * Lets us know if we have a value inside the config for a Panopto block,
+     * we don't want any of our events to fire on a disabled block.
+     *
+     */
+    public static function is_block_disabled() {
+        global $DB;
+
+        $sql = "SELECT * " .
+                "FROM {block} b " .
+                "WHERE b.name = :name AND b.visible = 0";
+        $isblockdisabled = $DB->get_record_sql($sql, ['name' => 'panopto']);
+
+        return $isblockdisabled ? true : false;
+    }
+
+    /**
      * Lets us know is we are using at least the minumum required version for the Panopto block
      *
      */
@@ -1777,7 +1793,7 @@ class panopto_data {
             'CURLOPT_RETURNTRANSFER' => true,
             'CURLOPT_HEADER' => false,
             'CURLOPT_HTTPHEADER' => ['Content-Type: application/json',
-                                          'Cookie: .ASPXAUTH='.$aspxauthcookie]
+                                          'Cookie: .ASPXAUTH='.$aspxauthcookie],
         ];
 
         $sockettimeout = get_config('block_panopto', 'panopto_socket_timeout');

--- a/lib/panopto_session_soap_client.php
+++ b/lib/panopto_session_soap_client.php
@@ -68,6 +68,24 @@ class panopto_session_soap_client extends PanoptoTimeoutSoapClient {
     private $sessionmanagementserviceget;
 
     /**
+     * @var SessionManagementServiceEnsure $sessionmanagementserviceensure soap service for ensure calls
+     */
+    private $sessionmanagementserviceensure;
+
+    /**
+     * @var SessionManagementServiceUnprovision $sessionmanagementserviceunprovision soap service for unprovision calls.
+     */
+    private $sessionmanagementserviceunprovision;
+
+    /**
+     * @var SessionManagementServiceUpdate $sessionmanagementserviceupdate soap service for update calls.
+     */
+    private $sessionmanagementserviceupdate;
+
+
+
+
+    /**
      * @var string PERSONAL_FOLDER_ERROR const string to return when user attempted to provision/sync a personal folder.
      * This action is not supported.
      */
@@ -625,7 +643,7 @@ class panopto_session_soap_client extends PanoptoTimeoutSoapClient {
             [
                 SessionManagementEnumSessionState::VALUE_BROADCASTING,
                 SessionManagementEnumSessionState::VALUE_COMPLETE,
-                SessionManagementEnumSessionState::VALUE_RECORDING
+                SessionManagementEnumSessionState::VALUE_RECORDING,
             ]
         );
 
@@ -790,7 +808,7 @@ class panopto_session_soap_client extends PanoptoTimeoutSoapClient {
     /**
      * Handle error
      *
-     * @param string $lasterror last error message
+     * @param object $lasterror last error message
      */
     private function handle_error($lasterror) {
         $ret = new stdClass;

--- a/lib/panopto_timeout_soap_client.php
+++ b/lib/panopto_timeout_soap_client.php
@@ -141,7 +141,7 @@ class PanoptoTimeoutSoapClient extends SoapClient {
                 'CURLOPT_RETURNTRANSFER' => true,
                 'CURLOPT_HEADER' => true,
                 'CURLOPT_HTTPHEADER' => ['Content-Type: text/xml',
-                                              'SoapAction: ' . $action]
+                                              'SoapAction: ' . $action],
             ];
 
             if (!is_null($this->socket_timeout)) {

--- a/lib/panopto_user_soap_client.php
+++ b/lib/panopto_user_soap_client.php
@@ -70,6 +70,16 @@ class panopto_user_soap_client extends PanoptoTimeoutSoapClient {
     private $usermanagementservicecreate;
 
     /**
+     * @var UserManagementServiceUpdate object used to call the user update service
+     */
+    private $usermanagementserviceupdate;
+
+    /**
+     * @var UserManagementServiceDelete object used to call the user delete service
+     */
+    private $usermanagementservicedelete;
+
+    /**
      * Main constructor
      *
      * @param string $servername

--- a/panopto_content.php
+++ b/panopto_content.php
@@ -38,6 +38,8 @@ try {
     $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
     require_login($course);
     require_sesskey();
+    // Close the session so that the users other tabs in the same session are not blocked.
+    \core\session\manager::write_close();
     header('Content-Type: text/html; charset=utf-8');
     global $CFG, $USER;
 

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 
 // Plugin version should normally be the same as the internal version.
 // If an admin wants to install with an older version number, however, set that here.
-$plugin->version = 2024012500;
+$plugin->version = 2024070900;
 
 // Requires this Moodle version - 4.1.0.
 $plugin->requires = 2022112800;
@@ -37,6 +37,6 @@ $plugin->cron = 0;
 $plugin->component = 'block_panopto';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
-    'mod_forum' => ANY_VERSION
+    'mod_forum' => ANY_VERSION,
 ];
 /* End of file version.php */


### PR DESCRIPTION
This is the current release version of the Panopto plug-in for Moodle. It is recommended that customers update to this version of the building block.

This version supports (a) Moodle 4.1, 4.2, 4.3, 4.4 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later.

Below is the list of updates from the previous release (2024012500).

- Added support for Moodle 4.4
- Fixed an issue where Panopto Course folders would have HTML in the folder names if a course category had multi-language content enabled.
- Fixed an issue where Panopto Course Copy V2 jobs would still be queued when a course is copied in Moodle, even if the Panopto Block is disabled.
- Improved performance when loading the Panopto Block in a Moodle course.
