### PR TITLE
Change custom file logging to $CFG->dataroot directory

### DIFF
--- a/lib/panopto_data.php
+++ b/lib/panopto_data.php
@@ -1877,7 +1877,7 @@ class panopto_data {
             if (get_config('block_panopto', 'print_log_to_file')) {
                 $currenttime = time();
                 file_put_contents(
-                    $CFG->dirroot . '/PanoptoLogs.txt', date("Y-m-d-h:i:sA", $currenttime) . ": " . $logmessage . "\n",
+                    $CFG->dataroot . '/PanoptoLogs.txt', date("Y-m-d-h:i:sA", $currenttime) . ": " . $logmessage . "\n",
                     FILE_APPEND
                 );
             } else {


### PR DESCRIPTION
## Description
Change the custom log directory, as some Moodle configurations prevent write access to `$CFG->dirroot`.