### PR TITLE
Provision courses via adhoc task

### DIFF
--- a/classes/task/provision_courses.php
+++ b/classes/task/provision_courses.php
@@ -1,0 +1,161 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provision courses task for Panopto.
+ *
+ * @package block_panopto
+ * @copyright  2025 onwards UCL {@link https://www.ucl.ac.uk/}
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_panopto\task;
+
+use core\output\stored_progress_bar;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(dirname(__FILE__) . '/../../lib/panopto_data.php');
+
+/**
+ * Provision courses task for Panopto.
+ */
+class provision_courses extends \core\task\adhoc_task {
+    use \core\task\stored_progress_task_trait;
+
+    /**
+     * The main execution function of the class
+     */
+    public function execute() {
+        global $OUTPUT;
+
+        $data = (array) $this->get_custom_data();
+        $courseids = $data['courseids'];
+        $selectedserver = $data['selectedserver'];
+        $selectedkey = $data['selectedkey'];
+
+        $this->progress = stored_progress_bar::get_by_idnumber($this->get_stored_progress_idnumber());
+        $this->progress->auto_update(false); // Suppress JavaScript output.
+
+        $provisioned = 0;
+
+        foreach ($courseids as $courseid) {
+            if (empty($courseid)) {
+                continue;
+            }
+
+            $provisioneddata = null;
+
+            try {
+                $panoptodata = new \panopto_data($courseid);
+
+                if ($panoptodata->servername !== $selectedserver) {
+                    $panoptodata->sessiongroupid = null;
+                }
+
+                $panoptodata->servername = $selectedserver;
+                $panoptodata->applicationkey = $selectedkey;
+                $provisioninginfo = $panoptodata->get_provisioning_info();
+                $provisioneddata = $panoptodata->provision_course($provisioninginfo, false);
+            } catch (\Exception $exception) {
+                mtrace_exception($exception);
+            }
+
+            if (
+                empty($provisioneddata) ||
+                isset($provisioneddata->errormessage) ||
+                isset($provisioneddata->accesserror) ||
+                isset($provisioneddata->unknownerror)
+            ) {
+                mtrace($OUTPUT->render_from_template('block_panopto/provisionerror.cli', $provisioneddata));
+            } else {
+                $templatedata = clone $provisioneddata;
+                $templatedata->fullname = $provisioninginfo->fullname;
+                $templatedata->userswillbesyncedcustom = get_config('block_panopto', 'sync_after_login') ||
+                    get_config('block_panopto', 'sync_on_enrolment');
+                $templatedata->asyncwaitwarning = get_config('block_panopto', 'async_tasks');
+                $templatedata->syncafterprovisioning = get_config('block_panopto', 'sync_after_provisioning');
+
+                if ($templatedata->syncafterprovisioning) {
+                    if (!empty($provisioneddata->publishers)) {
+                        $templatedata->publishers = join(', ', $provisioneddata->publishers);
+                    }
+
+                    if (!empty($provisioneddata->creators)) {
+                        $templatedata->creators = join(', ', $provisioneddata->creators);
+                    }
+
+                    if (!empty($provisioneddata->viewers)) {
+                        $templatedata->viewers = join(', ', $provisioneddata->viewers);
+                    }
+                }
+                mtrace($OUTPUT->render_from_template('block_panopto/provisionsuccess.cli', $templatedata));
+                $provisioned++;
+            }
+
+            $this->progress->update($provisioned, count($courseids), get_string('provisionsuccess', 'block_panopto', $provisioned));
+        }
+
+        if ($errorcount = count($courseids) - $provisioned) {
+            $this->progress->error(get_string('provisionerror', 'block_panopto', $errorcount));
+            throw new \moodle_exception('provisiontaskfail', 'block_panopto', '', $errorcount);
+        }
+    }
+
+    /**
+     * Method that can be called after creating this task but before it's
+     * started so that the progress instance ID exists, as this is needed to
+     * render a progress bar on the web page that corresponds to this task.
+     * @return string Unique ID for this task instance's progress.
+     */
+    public function progress_start(): string {
+        $this->start_stored_progress();
+        return $this->get_stored_progress_idnumber();
+    }
+
+    /**
+     * Override parent so we can render the progress bar on the web page (the
+     * parent trait sets the renderer to CLI).
+     */
+    protected function start_stored_progress(): void {
+        $this->progress = new stored_progress_bar($this->get_stored_progress_idnumber());
+
+        // Start the progress.
+        $this->progress->start();
+    }
+
+    /**
+     * Get the unique ID for this process.
+     * @return string Converted string, for example,
+     * block_panopto_task_provision_courses_118.
+     */
+    private function get_stored_progress_idnumber(): string {
+        // Construct a unique name for the progress bar.
+        $name = get_class($this) . '_' . $this->get_id();
+
+        return stored_progress_bar::convert_to_idnumber($name);
+    }
+
+    /**
+     * Used to indicate if the task should be re-run if it fails.
+     * By default, tasks will be retried until they succeed, other tasks can override this method to change this behaviour.
+     *
+     * @return bool true if the task should be retried until it succeeds, false otherwise.
+     */
+    public function retry_until_success(): bool {
+        return false;
+    }
+}

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -264,6 +264,9 @@ $string['provision_only_target_on_copy'] = 'Only provision the target course dur
 $string['provision_successful'] = 'Successfully provisioned course folder with Id: {$a}';
 $string['provisioncourseselect'] = 'Select courses to provision.';
 $string['provisioncourseselect_help'] = 'Multiple selections are possible by Ctrl-clicking (Windows) or Cmd-clicking (Mac).';
+$string['provisionerror'] = 'Error provisioning {$a} course(s), check logs for details.';
+$string['provisionsuccess'] = '{$a} course(s) successfully provisioned';
+$string['provisiontaskfail'] = 'Failed to provision {$a} courses';
 $string['publisher'] = 'Publisher';
 $string['publisher_help'] = 'A Publisher can approve content submitted by Creators';
 $string['publishers'] = 'Publishers';
@@ -306,4 +309,5 @@ $string['users_have_been_synced'] = 'The below users have been synced and should
 $string['users_will_be_synced_custom'] = 'Future users will automatically be synced according to your custom Panopto settings.';
 $string['verifying_permission'] = 'Verifying permission';
 $string['viewers'] = 'Viewers';
+$string['viewtasklog'] = 'Once the task has completed, <a href="{$a}">view the logs</a> to check the status.';
 $string['watch_live'] = 'Watch live';

--- a/provision_course.php
+++ b/provision_course.php
@@ -121,19 +121,28 @@ echo $OUTPUT->header();
 
 if ($courses) {
     $coursecount = count($courses);
-    // Raise PHP time limit for bulk provisioning operations to prevent timeouts.
-    // Only needed for large batches (50+ courses) where cumulative time could exceed limits.
-    if ($coursecount >= 50) {
-        core_php_time_limit::raise();
-    }
 
-    foreach ($courses as $courseid) {
-        if (empty($courseid)) {
-            continue;
+    if ($courseidparam === 0 && $coursecount > 0) {
+        $task = new \block_panopto\task\provision_courses();
+        $task->set_custom_data(['courseids' => $courses, 'selectedserver' => $selectedserver, 'selectedkey' => $selectedkey]);
+
+        if ($taskid = \core\task\manager::queue_adhoc_task($task)) {
+            $task->set_id($taskid);
+
+            if ($progressbaridnumber = $task->progress_start()) {
+                $progressbar = \core\output\stored_progress_bar::get_by_idnumber($progressbaridnumber);
+                echo $progressbar->get_content();
+                echo "<p>" .
+                    get_string(
+                        'viewtasklog',
+                        'block_panopto',
+                        new moodle_url('/admin/tasklogs.php', ['filter' => '\block_panopto\task\provision_courses'])
+                    ) . "</p>";
+            }
         }
-
+    } else {
         // Set the current Moodle course to retrieve info for / provision.
-        $panoptodata = new \panopto_data($courseid);
+        $panoptodata = new \panopto_data($courses[0]);
 
         // If an application key and server name are pre-set (happens when provisioning from multi-select page) use those,
         // otherwise retrieve values from the db.

--- a/templates/provisionerror.cli.mustache
+++ b/templates/provisionerror.cli.mustache
@@ -1,0 +1,32 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_panopto/provisionerror.cli
+
+    Error output when provision course fails in adhoc task.
+}}
+{{#errormessage}}
+    {{{.}}}
+{{/errormessage}}
+{{#accesserror}}
+    {{#str}} provision_access_error, block_panopto {{/str}}
+{{/accesserror}}
+{{#unknownerror}}
+    {{#str}} provision_error, block_panopto {{/str}}
+{{/unknownerror}}
+{{#str}} attempted_moodle_course_id, block_panopto {{/str}}: {{moodlecourseid}}
+{{#str}} attempted_panopto_server, block_panopto {{/str}}: {{servername}}

--- a/templates/provisionsuccess.cli.mustache
+++ b/templates/provisionsuccess.cli.mustache
@@ -1,0 +1,33 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_panopto/provisionsuccess.cli
+
+    Output when course successfully provisioned by adhoc task.
+}}
+{{#str}} course_name, block_panopto {{/str}}: {{fullname}}
+{{#str}} synced_user_info, block_panopto {{/str}}:
+{{#userswillbesyncedcustom}}{{#str}} users_will_be_synced_custom, block_panopto {{/str}}{{/userswillbesyncedcustom}}
+{{#asyncwaitwarning}}{{#str}} async_wait_warning, block_panopto {{/str}}{{/asyncwaitwarning}}
+{{#syncafterprovisioning}}{{#str}} users_have_been_synced, block_panopto {{/str}}
+{{#publishers}}{{#str}} publishers, block_panopto{{/str}} : {{.}}{{/publishers}}{{^publishers}}{{#str}} no_publishers, block_panopto{{/str}}{{/publishers}}
+{{#creators}}{{#str}} creators, block_panopto{{/str}} : {{.}}{{/creators}}{{^creators}}{{#str}} no_creators, block_panopto{{/str}}{{/creators}}
+{{#viewers}}{{#str}} viewers, block_panopto{{/str}} : {{.}}{{/viewers}}{{^viewers}}{{#str}} no_viewers, block_panopto{{/str}}{{/viewers}}
+{{/syncafterprovisioning}}
+{{^syncafterprovisioning}}{{#str}} no_users_synced_desc, block_panopto {{/str}}
+{{/syncafterprovisioning}}
+{{#str}} result, block_panopto {{/str}}: {{#str}} provision_successful, block_panopto, {{Id}} {{/str}}


### PR DESCRIPTION
## Description
Use an ad hoc task when provisioning courses from the `blocks/panopto/provision_course.php` page.

## Testing
I have tested provisioning courses with this.

I have tested the teacher's _Sync this course to Panopto_ link with this (this is still done synchronously, as before).

I have only tested this with Moodle 4.5.

## Jira Link
<!-- E.g. PC-### (link to Jira will populate automatically). Optional and Jira# must still be added to the PR title. -->