### PR TITLE
Build category structure asynchronously (#233)

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -61,18 +61,6 @@ jobs:
           - php: '8.3'
             moodle-branch: 'MOODLE_405_STABLE'
             database: 'mariadb'
-          - php: '8.3'
-            moodle-branch: 'MOODLE_404_STABLE'
-            database: 'pgsql'
-          - php: '8.2'
-            moodle-branch: 'MOODLE_403_STABLE'
-            database: 'mariadb'
-          - php: '8.1'
-            moodle-branch: 'MOODLE_402_STABLE'
-            database: 'pgsql'
-          - php: '8.1'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
 
     steps:
       # Check out this repository code in ./plugin directory

--- a/build_category_structure.php
+++ b/build_category_structure.php
@@ -32,7 +32,6 @@ require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/classes/panopto_build_category_structure_form.php');
 require_once(dirname(__FILE__) . '/lib/block_panopto_lib.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');
-require_once(dirname(__FILE__) . '/lib/panopto_category_data.php');
 
 // Populate list of servernames to select from.
 $aserverarray = [];
@@ -64,26 +63,6 @@ if (count($aserverarray) == 1) {
 }
 
 require_login();
-
-/**
- * The category structure process workhorse function
- *
- * @param string $selectedserver server name
- * @param string $selectedkey selected key
- */
-function build_category_structure($selectedserver, $selectedkey) {
-    global $DB;
-
-    $defaultmaxtime = ini_get('max_execution_time');
-
-    $twohoursinseconds = 7200;
-
-    set_time_limit($twohoursinseconds);
-
-    panopto_category_data::build_category_structure(true, $selectedserver, $selectedkey);
-
-    set_time_limit($defaultmaxtime);
-}
 
 $context = context_system::instance();
 
@@ -122,7 +101,24 @@ if ($mform->is_cancelled()) {
         $selectedserver = trim($aserverarray[$data->servers]);
         $selectedkey = trim($appkeyarray[$data->servers]);
 
-        build_category_structure($selectedserver, $selectedkey);
+        $task = new \block_panopto\task\build_category_structure();
+        $task->set_custom_data(['selectedserver' => $selectedserver, 'selectedkey' => $selectedkey]);
+
+        if ($taskid = \core\task\manager::queue_adhoc_task($task)) {
+            $task->set_id($taskid);
+
+            if ($progressbaridnumber = $task->progress_start()) {
+                $progressbar = \core\output\stored_progress_bar::get_by_idnumber($progressbaridnumber);
+                echo $progressbar->get_content();
+                echo "<p>" .
+                    get_string(
+                        'viewtasklog',
+                        'block_panopto',
+                        new moodle_url('/admin/tasklogs.php', ['filter' => '\block_panopto\task\build_category_structure '])
+                    ) .
+                    "</p>";
+            }
+        }
 
         echo "<a href='$returnurl'>" . get_string('back_to_config', 'block_panopto') . '</a>';
     } else {

--- a/classes/task/build_category_structure.php
+++ b/classes/task/build_category_structure.php
@@ -1,0 +1,97 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Build the necessary category structure for Panopto.
+ *
+ * @package block_panopto
+ * @author Leon Stringer <leon.stringer@ucl.ac.uk>
+ * @copyright 2025 onwards UCL {@link https://www.ucl.ac.uk/}
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_panopto\task;
+
+use core\output\stored_progress_bar;
+use panopto_category_data;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(dirname(__FILE__) . '/../../lib/panopto_category_data.php');
+
+/**
+ * Build necessary category structure.
+ */
+class build_category_structure extends \core\task\adhoc_task {
+    use \core\task\stored_progress_task_trait;
+
+    /**
+     * The main execution function of the class
+     */
+    public function execute() {
+        $data = (array) $this->get_custom_data();
+        $selectedserver = $data['selectedserver'];
+        $selectedkey = $data['selectedkey'];
+        $this->progress = stored_progress_bar::get_by_idnumber($this->get_stored_progress_idnumber());
+        $this->progress->auto_update(false); // Suppress JavaScript output.
+        panopto_category_data::build_category_structure(false, $selectedserver, $selectedkey, $this->progress);
+    }
+
+    /**
+     * Method that can be called after creating this task but before it's
+     * started so that the progress instance ID exists, as this is needed to
+     * render a progress bar on the web page that corresponds to this task.
+     *
+     * @return string Unique ID for this task instance's progress.
+     */
+    public function progress_start(): string {
+        $this->start_stored_progress();
+        return $this->get_stored_progress_idnumber();
+    }
+
+    /**
+     * Override parent so we can render the progress bar on the web page (the
+     * parent trait sets the renderer to CLI).
+     */
+    protected function start_stored_progress(): void {
+        $this->progress = new stored_progress_bar($this->get_stored_progress_idnumber());
+
+        // Start the progress.
+        $this->progress->start();
+    }
+
+    /**
+     * Get the unique ID for this process.
+     *
+     * @return string Converted string, for example,
+     * block_panopto_task_build_category_structure_118.
+     */
+    private function get_stored_progress_idnumber(): string {
+        // Construct a unique name for the progress bar.
+        $name = get_class($this) . '_' . $this->get_id();
+
+        return stored_progress_bar::convert_to_idnumber($name);
+    }
+
+    /**
+     * Used to indicate if the task should be re-run if it fails.
+     *
+     * @return bool true if the task should be retried until it succeeds, false otherwise.
+     */
+    public function retry_until_success(): bool {
+        return false;
+    }
+}

--- a/lang/en/block_panopto.php
+++ b/lang/en/block_panopto.php
@@ -169,6 +169,8 @@ $string['bulk_task_update_progress'] = 'Processing folder {$a->currentprogress} 
 $string['bulk_task_version_error'] = 'Panopto Bulk Operation Error - Panopto Server requires newer version';
 $string['bulk_task_working_count'] = 'Starting on folder {$a->beginningindex} and processing up to folder {$a->endingindex}';
 $string['categories_need_newer_panopto'] = 'Category calls need a Panopto server version of {$a->requiredpanoptoversion} to succeed, the targeted Panopto server\'s version is {$a->activepanoptoversion}.';
+$string['categoriesbuilderror'] = 'Categories build error';
+$string['categoriesbuilt'] = '{$a} categories built';
 $string['cli_category_invalid_arguments'] = 'Please run the command with the following arguments \'build_category_structure.php <panoptoservername> <applicationkey>\'';
 $string['cli_heading_build_category_structure'] = 'Sync all Moodle categories to Panopto';
 $string['completed_recordings'] = 'Completed recordings';
@@ -306,4 +308,5 @@ $string['users_have_been_synced'] = 'The below users have been synced and should
 $string['users_will_be_synced_custom'] = 'Future users will automatically be synced according to your custom Panopto settings.';
 $string['verifying_permission'] = 'Verifying permission';
 $string['viewers'] = 'Viewers';
+$string['viewtasklog'] = 'Once the task has completed, <a href="{$a}">view the logs</a> to check the status.';
 $string['watch_live'] = 'Watch live';

--- a/lib/panopto_category_data.php
+++ b/lib/panopto_category_data.php
@@ -21,6 +21,8 @@
  * @copyright  Panopto 2009 - 2018 /With contributions from Spenser Jones (sjones@ambrose.edu), and Tim Lock
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+use core\output\stored_progress_bar;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -368,8 +370,14 @@ class panopto_category_data {
      * @param bool $usehtmloutput if we should use html output or not
      * @param string $selectedserver server name
      * @param string $selectedkey selected key
+     * @param ?stored_progress_bar $progress Optional progress bar to update during build.
      */
-    public static function build_category_structure($usehtmloutput, $selectedserver, $selectedkey) {
+    public static function build_category_structure(
+        $usehtmloutput,
+        $selectedserver,
+        $selectedkey,
+        ?stored_progress_bar $progress = null
+    ) {
         global $CFG, $DB;
 
         \panopto_data::print_log(get_string('build_category_structure_start', 'block_panopto', $selectedserver));
@@ -392,11 +400,19 @@ class panopto_category_data {
             $leafcategories = $DB->get_records_sql(
                 'SELECT id FROM {course_categories} WHERE id NOT IN (SELECT parent FROM {course_categories})'
             );
+            $built = 0;
 
             foreach ($leafcategories as $leafcategory) {
                 $categorybuilder->moodlecategoryid = $leafcategory->id;
                 $categorybuilder->sessiongroupid = self::get_panopto_category_id($leafcategory->id, $selectedserver);
-                $categorybuilder->ensure_category_branch($usehtmloutput, null);
+                if ($categorybuilder->ensure_category_branch(false, null) && $progress) {
+                    $built++;
+                    $progress->update($built, count($leafcategories), get_string('categoriesbuilt', 'block_panopto', $built));
+                }
+            }
+            if ($built < count($leafcategories) && $progress) {
+                $progress->error(get_string('categoriesbuilderror', 'block_panopto'));
+                \panopto_data::print_log('categoriesbuilderror', 'block_panopto');
             }
         }
     }

--- a/version.php
+++ b/version.php
@@ -31,8 +31,8 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 // If an admin wants to install with an older version number, however, set that here.
 $plugin->version = 2026022500;
 
-// Requires this Moodle version - 4.1.0.
-$plugin->requires = 2022112800;
+// Requires this Moodle version - 4.5.0.
+$plugin->requires = 2024100700;
 $plugin->cron = 0;
 $plugin->component = 'block_panopto';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Description

Move the functionality to build the category structure into an ad hoc task. This allows the process to complete asynchronously in the background instead of potentially being cancelled by the web page timing out.

If you stay on the `blocks/panopto/build_category_structure.php` page a progress bar is shown indicating how many categories have been built.

The block_panopto setting _Print Verbose Logs_ must be enabled to see categories in the task log output as this is the existing functionality for `lib/cli/build_category_structure_cli.php`.

## Testing

This change requires Moodle 4.5 since `stored_progress_task_trait` is not available with earlier versions.


## Jira Link
N/A