### PR TITLE
Fix: Increment on type bool has no effect

### DIFF
--- a/lib/block_panopto_lib.php
+++ b/lib/block_panopto_lib.php
@@ -128,8 +128,7 @@ function panopto_generate_wsdl_service_params($apiurl) {
  */
 function panopto_get_configured_panopto_servers() {
 
-    $numservers = get_config('block_panopto', 'server_number');
-    $numservers = isset($numservers) ? $numservers : 0;
+    $numservers = get_config('block_panopto', 'server_number') ?: 0;
 
     // Increment numservers by 1 to take into account starting at 0.
     ++$numservers;

--- a/settings.php
+++ b/settings.php
@@ -31,8 +31,7 @@ if (empty($CFG)) {
 require_once(dirname(__FILE__) . '/classes/admin/trim_configtext.php');
 require_once(dirname(__FILE__) . '/lib/panopto_data.php');
 
-$numservers = get_config('block_panopto', 'server_number');
-$numservers = isset($numservers) ? $numservers : 0;
+$numservers = get_config('block_panopto', 'server_number') ?: 0;
 
 // Increment numservers by 1 to take into account starting at 0.
 ++$numservers;


### PR DESCRIPTION
## Description
#224  Fix Increment on type bool has no effect


## Testing
Set up a Moodle site using PHP 8.3.
Enable debugging.
Extract block_panopto into `blocks/panopto`.
Install the plugin at the command line by running `admin/cli/upgrade.php`.

Expected results:
There should be no errors or warnings, specifically the following messages should not appear:

```
PHP Warning:  Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/moodle/blocks/panopto/settings.php on line 38

Warning: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/moodle/blocks/panopto/settings.php on line 38
PHP Warning:  Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/moodle/blocks/panopto/lib/block_panopto_lib.php on line 135

Warning: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/moodle/blocks/panopto/lib/block_panopto_lib.php on line 135
```

## Jira Link
<!-- E.g. PC-### (link to Jira will populate automatically). Optional and Jira# must still be added to the PR title. -->