### PR TITLE
external: Use current classes, not deprecated externallib

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -70,9 +70,6 @@ jobs:
           - php: '8.1'
             moodle-branch: 'MOODLE_402_STABLE'
             database: 'pgsql'
-          - php: '8.1'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
 
     steps:
       # Check out this repository code in ./plugin directory

--- a/classes/external/get_content.php
+++ b/classes/external/get_content.php
@@ -26,13 +26,12 @@ namespace block_panopto\external;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . '/externallib.php');
 require_once(dirname(__FILE__) . '/../../lib/panopto_data.php');
 
-use external_api;
-use external_function_parameters;
-use external_value;
-use external_single_structure;
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 
 /**
  * External service for getting Panopto content.

--- a/version.php
+++ b/version.php
@@ -31,8 +31,8 @@ $plugin = (isset($plugin) ? $plugin : new stdClass());
 // If an admin wants to install with an older version number, however, set that here.
 $plugin->version = 2026022500;
 
-// Requires this Moodle version - 4.1.0.
-$plugin->requires = 2022112800;
+// Requires this Moodle version - 4.2.0.
+$plugin->requires = 2023042400;
 $plugin->cron = 0;
 $plugin->component = 'block_panopto';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Description

externallib.php has been deprecated for a few years. The relevant pieces that it provides are the class aliases. So if we stop using the aliases and use the current class names (which are in Moodle 4.2), then we can drop the externallib.php require. The latest release of this plugin says that it supports Moodle 4.5 and newer, but did not increase the `requires` value in version.php. Because this change does require Moodle 4.2 or newer, I reflecting that requirement in version.php. Feel free to modify the `requires` value to `2024100700` if you do really want to require Moodle 4.5. Otherwise, I think that this is sufficient.

## Testing

The phpunit tests passed.