### PR TITLE
fixexternaltest

### DIFF
--- a/classes/external/get_content.php
+++ b/classes/external/get_content.php
@@ -26,10 +26,8 @@ namespace block_panopto\external;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . '/externallib.php');
 require_once(dirname(__FILE__) . '/../../lib/panopto_data.php');
 
-use external_api;
 use external_function_parameters;
 use external_value;
 use external_single_structure;
@@ -41,7 +39,7 @@ use external_single_structure;
  * @copyright Panopto 2009 - 2025
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class get_content extends external_api {
+class get_content extends \core_external\external_api {
     /**
      * Returns description of method parameters
      * @return external_function_parameters


### PR DESCRIPTION
This will fix external_api_test error

vendor/bin/phpunit lib/external/tests/external_api_test.php
There was 1 error:
1) core_external\external_api_test::test_all_external_info with data set "block_panopto_get_content" (stdClass Object (...))
Error: Class "external_function_parameters" not found
/builds/elearning/moodle/blocks/panopto/classes/external/get_content.php:48
/builds/elearning/moodle/lib/external/classes/external_api.php:110
/builds/elearning/moodle/lib/external/tests/external_api_test.php:401
/builds/elearning/moodle/lib/phpunit/classes/advanced_testcase.php:76
ERRORS!
